### PR TITLE
Nix automation for valgrind

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,12 +68,11 @@
         program = pkgs.lib.getExe (pkgs.writeShellScriptBin "memuse" ''
           INPUT=''${1:-kitten.mcap}
           if [ -f $INPUT ]; then
-          ${pkgs.lib.getExe' pkgs.valgrind "valgrind"} --tool=massif --time-unit=B --massif-out-file=data/heap.usage.massif -- ${pkgs.lib.getExe self.packages.${system}.default} encrypt $INPUT --ciphertext data/kitten.mcap.mcap
+          ${pkgs.lib.getExe' pkgs.valgrind "valgrind"} --tool=massif --time-unit=B --massif-out-file=data/heap.usage.massif -- ${pkgs.lib.getExe self.packages.${system}.default} encrypt $INPUT --ciphertext data/output.mcap
           HEAP=''$(${pkgs.lib.getExe pkgs.ripgrep} mem_heap_B data/heap.usage.massif|cut -d '=' -f 2|sort -r -g|head -n 1)
-          SIZE=''$(du -b $INPUT)
+          SIZE=''$(du -b $INPUT|cut -f 1)
           echo "Max heap usage of $HEAP bytes for encoding $SIZE bytes"
-          # Clearly I am bad at doing math in the shell.
-          # echo "Max heap used is ''$(printf '2.f\n' "$(($HEAP*100/$SIZE))e-2") percent of the input file."
+          echo "Max heap used is ''$(($HEAP*100/$SIZE)) percent of the input file."
           fi
         '');
       };

--- a/flake.nix
+++ b/flake.nix
@@ -46,8 +46,17 @@
           ];
         };
     apps.${system} = {
+
+      paramtest = {
+        type = "app";
+        program = pkgs.lib.getExe (pkgs.writeShellScriptBin "paramtest" ''
+          echo ''${1:-defaultvalue}
+        '');
+      };
+
       cov = {
         type = "app";
+        meta.description = "run tests and report coverage by opening a new firefox tab.";
         program = pkgs.lib.getExe (pkgs.writeShellScriptBin "cov" ''
           cargo llvm-cov --html
           ${pkgs.firefox} --new-tab --url ./target/llvm-cov/html/index.html
@@ -55,9 +64,17 @@
       };
       memuse = {
         type = "app";
+        meta.description = "run valgrind wrapping magic-cap, report the max heap usage.";
         program = pkgs.lib.getExe (pkgs.writeShellScriptBin "memuse" ''
-          ${pkgs.lib.getExe' pkgs.valgrind "valgrind"} --tool=massif --time-unit=B --massif-out-file=data/heap.usage.massif -- ${pkgs.lib.getExe self.packages.${system}.default} encrypt kitten.mcap --ciphertext kitten.mcap.mcap
-          ${pkgs.lib.getExe pkgs.ripgrep} mem_heap_B data/heap.usage.massif|cut -d '=' -f 2|sort -r -g|head -n 1
+          INPUT=''${1:-kitten.mcap}
+          if [ -f $INPUT ]; then
+          ${pkgs.lib.getExe' pkgs.valgrind "valgrind"} --tool=massif --time-unit=B --massif-out-file=data/heap.usage.massif -- ${pkgs.lib.getExe self.packages.${system}.default} encrypt $INPUT --ciphertext data/kitten.mcap.mcap
+          HEAP=''$(${pkgs.lib.getExe pkgs.ripgrep} mem_heap_B data/heap.usage.massif|cut -d '=' -f 2|sort -r -g|head -n 1)
+          SIZE=''$(du -b $INPUT)
+          echo "Max heap usage of $HEAP bytes for encoding $SIZE bytes"
+          # Clearly I am bad at doing math in the shell.
+          # echo "Max heap used is ''$(printf '2.f\n' "$(($HEAP*100/$SIZE))e-2") percent of the input file."
+          fi
         '');
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,7 @@
             cargo-wizard
             clippy
             gnuplot
+            valgrind
           ];
         };
     apps.${system} = {
@@ -49,13 +50,14 @@
         type = "app";
         program = pkgs.lib.getExe (pkgs.writeShellScriptBin "cov" ''
           cargo llvm-cov --html
-          firefox --new-tab --url ./target/llvm-cov/html/index.html
+          ${pkgs.firefox} --new-tab --url ./target/llvm-cov/html/index.html
         '');
       };
       memuse = {
         type = "app";
         program = pkgs.lib.getExe (pkgs.writeShellScriptBin "memuse" ''
-          ${pkgs.lib.getExe' pkgs.valgrind "valgrind"} --tool=dhat --mode=heap -- ${pkgs.lib.getExe self.packages.${system}.default}
+          ${pkgs.lib.getExe' pkgs.valgrind "valgrind"} --tool=massif --time-unit=B --massif-out-file=data/heap.usage.massif -- ${pkgs.lib.getExe self.packages.${system}.default} encrypt kitten.mcap --ciphertext kitten.mcap.mcap
+          ${pkgs.lib.getExe pkgs.ripgrep} mem_heap_B data/heap.usage.massif|cut -d '=' -f 2|sort -r -g|head -n 1
         '');
       };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -4,52 +4,60 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
     rust-overlay = { url = "github:oxalica/rust-overlay"; };
   };
-  outputs = { nixpkgs, rust-overlay, ... }:
-    let
-      system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
-    in {
-      packages.${system}.default =
-        let
-          pkgs = import nixpkgs { inherit system; };
-            in pkgs.rustPlatform.buildRustPackage {
-              pname = "magic_cap";
-              buildInputs = [ ];
-              version = "0.1.0";
-              cargoLock.lockFile = ./Cargo.lock;
-              src = pkgs.lib.cleanSource ./.;
-            };
-            devShells.${system}.default =
-              let pkgs = import nixpkgs {
-                    inherit system;
-                    overlays = [ (import rust-overlay) ];
-                    config.allowUnfree = true;
-                  };
-              in
-                pkgs.mkShell {
-                  packages = with pkgs; [
-                    llvmPackages.llvm
-                    (rust-bin.stable.latest.default.override {
-                      extensions = [ "rust-analyzer" "rust-src" "llvm-tools-preview" ];
-                    })
-                    cargo
-                    cargo-autoinherit
-                    cargo-depgraph
-                    cargo-duplicates
-                    cargo-edit
-                    cargo-llvm-cov
-                    cargo-wizard
-                    clippy
-                    gnuplot
-                  ];
-                };
-      apps.${system}.cov = {
+  outputs = { self, nixpkgs, rust-overlay, ... }:
+  let
+    system = "x86_64-linux";
+    pkgs = import nixpkgs { inherit system; };
+  in {
+    packages.${system}.default =
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in pkgs.rustPlatform.buildRustPackage {
+        pname = "magic-cap";
+        buildInputs = [ ];
+        version = "0.1.0";
+        cargoLock.lockFile = ./Cargo.lock;
+        src = pkgs.lib.cleanSource ./.;
+        meta.mainProgram = "mcap";
+      };
+    devShells.${system}.default =
+      let pkgs = import nixpkgs {
+        inherit system;
+        overlays = [ (import rust-overlay) ];
+        config.allowUnfree = true;
+      };
+      in
+        pkgs.mkShell {
+          packages = with pkgs; [
+            llvmPackages.llvm
+            (rust-bin.stable.latest.default.override {
+              extensions = [ "rust-analyzer" "rust-src" "llvm-tools-preview" ];
+            })
+            cargo
+            cargo-autoinherit
+            cargo-depgraph
+            cargo-duplicates
+            cargo-edit
+            cargo-llvm-cov
+            cargo-wizard
+            clippy
+            gnuplot
+          ];
+        };
+    apps.${system} = {
+      cov = {
         type = "app";
         program = pkgs.lib.getExe (pkgs.writeShellScriptBin "cov" ''
-          #!env bash
           cargo llvm-cov --html
           firefox --new-tab --url ./target/llvm-cov/html/index.html
-          '');
+        '');
+      };
+      memuse = {
+        type = "app";
+        program = pkgs.lib.getExe (pkgs.writeShellScriptBin "memuse" ''
+          ${pkgs.lib.getExe' pkgs.valgrind "valgrind"} --tool=dhat --mode=heap -- ${pkgs.lib.getExe self.packages.${system}.default}
+        '');
       };
     };
+  };
 }

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/6yranb0507mz2vzl9r0zgyf88l58pdph-magic_cap-0.1.0


### PR DESCRIPTION
This PR adds a "memuse" command to the nix flake.

You can run the command with `nix run '.#memuse'`, or optionally `nix run '.#memuse' largefile.mp4`

Here's an example run:

```
❯ nix run '.#memuse'
warning: Git tree '/home/shae/build/magic-cap' is dirty
==29583== Massif, a heap profiler
==29583== Copyright (C) 2003-2024, and GNU GPL'd, by Nicholas Nethercote et al.
==29583== Using Valgrind-3.26.0 and LibVEX; rerun with -h for copyright info
==29583== Command: /nix/store/szh8waxdh3cgk3jck8848ycl46rz10ng-magic-cap-0.1.0/bin/mcap encrypt kitten.mcap --ciphertext data/output.mcap
==29583==
mcap0r5g69pVye2EKI6PZyt3pLsFJaqg_7FUfISgi4MLsqJACB_OWYwzilevHYhjpeYlwE
==29583==
Max heap usage of 60087 bytes for encoding 311615       kitten.mcap bytes
```

Here's a run with a larger file:

```
❯ nix run '.#memuse' data/sicherman.mp4
warning: Git tree '/home/shae/build/magic-cap' is dirty
==29999== Massif, a heap profiler
==29999== Copyright (C) 2003-2024, and GNU GPL'd, by Nicholas Nethercote et al.
==29999== Using Valgrind-3.26.0 and LibVEX; rerun with -h for copyright info
==29999== Command: /nix/store/szh8waxdh3cgk3jck8848ycl46rz10ng-magic-cap-0.1.0/bin/mcap encrypt data/sicherman.mp4 --ciphertext data/output.mcap
==29999==
mcap0rPJJjq3il4UNz_D8Rv_NszlJq-zzf5PN1uKTaXU6sncFR8TnI3ZWX2APYLSv_XSoY
==29999==
Max heap usage of 10505662 bytes for encoding 111895283 data/sicherman.mp4 bytes
```

I was hoping to add a line "heap used is $PERCENT of input" but I am not yet able to do math in the shell, and would appreciate help.