### PR TITLE
Arggroup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,12 +97,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,9 +110,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -126,14 +120,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -159,9 +154,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -174,22 +169,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
-]
-
-[[package]]
-name = "bstr"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
-dependencies = [
- "memchr",
- "regex-automata",
- "serde",
 ]
 
 [[package]]
@@ -200,53 +184,9 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-
-[[package]]
-name = "cargo-config2"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ada53f7339c78084fb37d7e17f34e76537541c4fbb02fa3a2baa14b8faad37"
-dependencies = [
- "serde",
- "serde_derive",
- "toml",
-]
-
-[[package]]
-name = "cargo-llvm-cov"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb60793c145d8ef09b5cfa49c2f2890b93bde5a13885a9369654ca87dddfe7f"
-dependencies = [
- "anyhow",
- "camino",
- "cargo-config2",
- "duct",
- "fs-err",
- "glob",
- "lcov2cobertura",
- "lexopt",
- "opener",
- "regex",
- "rustc-demangle",
- "ruzstd",
- "serde",
- "serde_derive",
- "serde_json",
- "shell-escape",
- "tar",
- "termcolor",
- "walkdir",
-]
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -256,9 +196,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -311,7 +251,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "crypto-common 0.2.2",
  "inout",
 ]
@@ -607,7 +547,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
@@ -631,18 +571,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bda8e21c04aca2ae33ffc2fd8c23134f3cac46db123ba97bd9d3f3b8a4a85e1"
 
 [[package]]
-name = "duct"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e66e9c0c03d094e1a0ba1be130b849034aa80c3a2ab8ee94316bc809f3fa684"
-dependencies = [
- "libc",
- "os_pipe",
- "shared_child",
- "shared_thread",
-]
-
-[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -650,9 +578,9 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "encoding_rs"
@@ -686,16 +614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "filetime"
-version = "0.2.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
-dependencies = [
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,27 +626,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "fs-err"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -825,28 +728,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -880,15 +775,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -919,9 +805,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -958,9 +844,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -1109,12 +995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1165,8 +1045,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1290,13 +1168,12 @@ checksum = "8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1311,30 +1188,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lcov2cobertura"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf5d75e3487295500b5426ad473805696126915b3e647ecdd5b9597a17766c6a"
-dependencies = [
- "anyhow",
- "quick-xml",
- "regex",
- "rustc-demangle",
-]
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
-name = "lexopt"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803ec87c9cfb29b9d2633f20cba1f488db3fd53f2158b1024cbefb47ba05d413"
 
 [[package]]
 name = "libc"
@@ -1365,9 +1218,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1380,12 +1233,11 @@ name = "magic_cap"
 version = "0.0.1"
 dependencies = [
  "aes",
- "cargo-llvm-cov",
  "cipher",
  "criterion",
  "ctr",
  "data-encoding",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hkdf",
  "include-doc",
  "proptest",
@@ -1421,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memoffset"
@@ -1458,15 +1310,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ffbca2f655e33c08be35d87278e5b18b89550a37dbd598c20db92f6a471123"
 dependencies = [
  "windows-sys 0.42.0",
-]
-
-[[package]]
-name = "normpath"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9985ef7269fa99f3b12437bb698381da2428743ab90f20393f399fa14cab21a"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1506,31 +1349,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "opener"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fa337e0cf13357c13ef1dc108df1333eb192f75fc170bea03fcf1fd404c2ee"
-dependencies = [
- "bstr",
- "normpath",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "os_pipe"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
-dependencies = [
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "page_size"
@@ -1587,6 +1409,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,16 +1461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1677,26 +1495,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
-name = "quick-xml"
-version = "0.39.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "socket2",
  "thiserror",
@@ -1707,9 +1516,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -1717,7 +1526,7 @@ dependencies = [
  "lru-slab",
  "rand",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash 2.1.3",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -1743,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1919,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1942,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2021,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "rowan"
-version = "0.15.18"
+version = "0.15.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f509095fc8cc0c8c8564016771d458079c11a8d857e65861f045145c0d3208"
+checksum = "a2441aaccb50f4267d4f0f58b21e0138e96a449f361ed57a2673a83c9bca0772"
 dependencies = [
  "countme",
  "hashbrown 0.14.5",
@@ -2042,12 +1851,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,9 +1858,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2083,9 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2109,9 +1912,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2173,12 +1976,6 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
-
-[[package]]
-name = "ruzstd"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
 
 [[package]]
 name = "same-file"
@@ -2277,15 +2074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,28 +2105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shared_child"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "shared_thread"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b86057fcb5423f5018e331ac04623e32d6b5ce85e33300f92c79a1973928b0"
-
-[[package]]
-name = "shell-escape"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
-
-[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,9 +2134,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smol_str"
@@ -2411,9 +2177,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2462,36 +2228,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tar"
-version = "0.4.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -2602,37 +2348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
-dependencies = [
- "serde_core",
- "serde_spanned",
- "toml_datetime",
- "toml_parser",
- "winnow",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,9 +2451,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd69c5aa8f924c7519d6372789a74eac5b94fb0f8fcf0d4a97eb0bfc3e785f39"
+checksum = "b40688ea6389c8171614b25491f71d4a27946e0c7ce2da1c6de27e25abf1a0ae"
 
 [[package]]
 name = "try-lock"
@@ -2889,27 +2604,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2920,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2930,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2940,9 +2646,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2953,52 +2659,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3016,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3303,120 +2975,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
-name = "winnow"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
 name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "xattr"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
-dependencies = [
- "libc",
- "rustix",
-]
 
 [[package]]
 name = "yoke"
@@ -3443,18 +3011,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3484,9 +3052,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,15 @@ members = ["magic_cap", "mcap"]
 
 [workspace.dependencies]
 aes = "0.9.1"
-bytes = "1.11.1"
-cargo-llvm-cov = "*"
+bytes = "1.12.0"
+# <2026-07-03 Fri> until quick-xml vulnerability is fixed, no more cargo-llvm-cov
+# cargo-llvm-cov = "*"
 cipher = "0.5.2"
 clap = "4.6.1"
 criterion = "0.8"
 ctr = "0.10.1"
 data-encoding = "2.11.0"
-getrandom = "0.4.2"
+getrandom = "0.4.3"
 include-doc = "0.2.2"
 magic_cap = { version = "0.0.1", path = "magic_cap" }
 proptest = "1.11.0"

--- a/encode-kittens.py
+++ b/encode-kittens.py
@@ -30,6 +30,6 @@ for k in os.listdir(kittens):
 
 with Path("data/kittens-anthology.txt").open("w") as f:
     for k in sorted(caps.keys()):
-        line = f"{k:>30} {caps[k]}"
+        line = f"{caps[k]} {k}"
         print(line)
         f.write(line + "\n")

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
               extensions = [ "rust-analyzer" "rust-src" "llvm-tools-preview" ];
             })
             cargo
+            cargo-audit
             cargo-autoinherit
             cargo-depgraph
             cargo-duplicates

--- a/magic_cap/Cargo.toml
+++ b/magic_cap/Cargo.toml
@@ -44,7 +44,7 @@ hkdf = { workspace = true  }
 proptest = { workspace = true }
 tempfile = { workspace = true }
 criterion = { workspace = true, features = ["html_reports"] }
-cargo-llvm-cov = { workspace = true }
+# cargo-llvm-cov = { workspace = true }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["proptest"]

--- a/magic_cap/examples/in-memory.rs
+++ b/magic_cap/examples/in-memory.rs
@@ -9,7 +9,7 @@ fn main() {
         println!("Read Cap: {:?}", readcap);
 
         let verifycap: ImmutableVerifyCap = readcap.into();
-        if !verifycap.corresponds_to(&immutable) {
+        if !verifycap.corresponds_to(&immutable.metadata) {
             println!("Verify Cap does not match data");
         }
     }

--- a/magic_cap/src/catalog.rs
+++ b/magic_cap/src/catalog.rs
@@ -132,7 +132,7 @@ impl ImmutableWebCatalog {
         // figure out of this looks like a Magic Cap Catalog version 0 REST API
         let url = root.clone();
         let url = url.join("magic-cap-catalog").unwrap();
-        debug!("url is {}",url);
+        debug!("url is {}", url);
         let result = reqwest::blocking::Client::new().get(url).send()?;
         debug!("before js result.text");
         let js = result.text()?;
@@ -153,7 +153,10 @@ impl ImmutableWebCatalog {
         let url = url.join((id_str + "/").as_str()).unwrap();
         let url = url.join("metadata").unwrap();
         debug!("URL {:?}", url);
-        let result = reqwest::blocking::Client::new().get(url).send()?.error_for_status()?;
+        let result = reqwest::blocking::Client::new()
+            .get(url)
+            .send()?
+            .error_for_status()?;
         debug!("before js = result.bytes");
         let js = result.bytes()?;
         let slice = &js[0..];

--- a/magic_cap/src/catalog.rs
+++ b/magic_cap/src/catalog.rs
@@ -131,6 +131,7 @@ impl ImmutableWebCatalog {
         // figure out of this looks like a Magic Cap Catalog version 0 REST API
         let url = root.clone();
         let url = url.join("magic-cap-catalog").unwrap();
+        debug!("url is {}",url);
         let result = reqwest::blocking::Client::new().get(url).send()?;
         let js = result.text()?;
         let js: Value = serde_json::from_str(js.as_str()).unwrap();

--- a/magic_cap/src/catalog.rs
+++ b/magic_cap/src/catalog.rs
@@ -128,13 +128,16 @@ pub struct ImmutableWebCatalog {
 
 impl ImmutableWebCatalog {
     pub fn create(root: Url) -> Result<ImmutableWebCatalog, MagicCapError> {
+        debug!("start of ImmutableWebCatalog create");
         // figure out of this looks like a Magic Cap Catalog version 0 REST API
         let url = root.clone();
         let url = url.join("magic-cap-catalog").unwrap();
         debug!("url is {}",url);
         let result = reqwest::blocking::Client::new().get(url).send()?;
+        debug!("before js result.text");
         let js = result.text()?;
         let js: Value = serde_json::from_str(js.as_str()).unwrap();
+        debug!("before js version check");
         if js["version"] == 0 {
             return Ok(ImmutableWebCatalog { root });
         }
@@ -150,7 +153,8 @@ impl ImmutableWebCatalog {
         let url = url.join((id_str + "/").as_str()).unwrap();
         let url = url.join("metadata").unwrap();
         debug!("URL {:?}", url);
-        let result = reqwest::blocking::Client::new().get(url).send()?;
+        let result = reqwest::blocking::Client::new().get(url).send()?.error_for_status()?;
+        debug!("before js = result.bytes");
         let js = result.bytes()?;
         let slice = &js[0..];
         Ok(rmp_serde::decode::from_read(slice)?)

--- a/magic_cap/src/catalog.rs
+++ b/magic_cap/src/catalog.rs
@@ -49,7 +49,7 @@ impl std::convert::From<&ImmutableVerifyCap> for ImmutableIdentifier {
     }
 }
 
-impl<'a> std::convert::From<&Immutable<'a>> for ImmutableIdentifier {
+impl std::convert::From<&Immutable<'_>> for ImmutableIdentifier {
     fn from(imm: &Immutable) -> ImmutableIdentifier {
         let verify: ImmutableVerifyCap = ImmutableVerifyCap::from(&imm.metadata);
         ImmutableIdentifier {

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -385,7 +385,7 @@ pub fn derive_key(key_bytes: &[u8; 16], purpose: &str) -> TahoeAesCtr {
 
     let hk = Hkdf::<Sha256>::new(None, key_bytes); //from_prk(&self.key).unwrap();
     let mut derived_key: Vec<u8> = vec![0u8; 32];
-    hk.expand(&info, &mut derived_key).unwrap();
+    hk.expand(info, &mut derived_key).unwrap();
 
     // newer versions of RustCrypto depend on "hybrid-array" instead
     // of "generic-array".  in (older) "generic-array" versions, there
@@ -976,7 +976,7 @@ impl ImmutableMetadata {
     pub fn secret_metadata(&self, cap: &ImmutableReadCap) -> SecretImmutableMetadata {
         decrypt_metadata(
             derive_key(&cap.key, "magic-cap-metadata-0"),
-            &(*self._secret_metadata),
+            &self._secret_metadata,
         )
         .unwrap()
     }

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -799,6 +799,15 @@ impl std::convert::TryFrom<&str> for ImmutableReadCap {
     }
 }
 
+impl std::str::FromStr for ImmutableReadCap {
+    type Err = MagicCapError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        ImmutableReadCap::try_from(s)
+    }
+
+}
+
 fn vec_to_array<T, const BLOCKSIZE: usize>(v: Vec<T>) -> Result<[T; BLOCKSIZE], MagicCapError> {
     // todo: surely we can type this shorter, but we so far failed
     let result = v.try_into();

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -285,8 +285,8 @@ pub struct ImmutableVerifyCap {
 impl ImmutableVerifyCap {
     /// returns true IFF the hash of the passed metadata matches that
     /// in this VerifyCap
-    pub fn corresponds_to(&self, immutable: &Immutable) -> bool {
-        let h = ImmutableVerifyCap::from(&immutable.metadata);
+    pub fn corresponds_to(&self, metadata: &ImmutableMetadata) -> bool {
+        let h = ImmutableVerifyCap::from(metadata);
         h.metadata_hash == self.metadata_hash
     }
 }
@@ -300,7 +300,7 @@ impl ImmutableVerifier for ImmutableVerifyCap {
         // before anything else, we check that the capability
         // corresponds to this Immutable ... by hashing the Metadata,
         // and confirming it matches the Cap's hash
-        if !self.corresponds_to(immutable) {
+        if !self.corresponds_to(&immutable.metadata) {
             return Err(MagicCapError::McapMetadataDiscordant());
         }
 
@@ -333,7 +333,7 @@ impl ImmutableVerifier for ImmutableVerifyCap {
 /// A Cap that is able to both verify the ciphertext and decrypt it
 ///
 /// Use `Display` and `TryFrom` to convert to and from human-usable
-/// rendintions of this data.
+/// renditions of this data.
 ///
 /// For example:
 ///
@@ -630,7 +630,7 @@ impl ReadCap for ImmutableReadCap {
                 immutable.data_provider.block_size() as usize,
             ));
         }
-        if !self.verify.corresponds_to(immutable) {
+        if !self.verify.corresponds_to(&immutable.metadata) {
             return Err(MagicCapError::McapMetadataDiscordant());
         }
 
@@ -681,7 +681,7 @@ impl ReadCap for ImmutableReadCap {
         // before anything else, we check that the capability
         // corresponds to this Immutable ... by hashing the Metadata,
         // and confirming it matches the Cap's hash
-        if !self.verify.corresponds_to(immutable) {
+        if !self.verify.corresponds_to(&immutable.metadata) {
             return Err(MagicCapError::McapMetadataDiscordant());
         }
 

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -509,7 +509,6 @@ where
         // boring way
         trace!("ImmutableBuilder::write: {} bytes", buf.len());
         self.this_block.write(buf)?;
-        let mut local_written = 0;
         // if we have a non-full block of plaintext when done() is
         // called, it is padded with 0's and encrypted as the final
         // block.
@@ -524,7 +523,6 @@ where
             };
             // write out a block
             self.output.write_all(&encrypted_block)?;
-            local_written += encrypted_block.len();
             self.ciphertext_bytes += encrypted_block.len();
         }
 

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -695,7 +695,7 @@ impl ReadCap for ImmutableReadCap {
             let lh = TahoeLeaf::hash(&leaf);
             leaves.push(lh);
         }
-        //fill_empty_merkle_leaves(&mut leaves);
+        fill_empty_merkle_leaves(&mut leaves);
 
         let merkle_tree = MerkleTree::<TahoeInside>::from_leaves(&leaves);
         let merkle_root = merkle_tree.root().ok_or(MagicCapError::MerkleError())?;
@@ -954,7 +954,9 @@ pub struct ImmutableMetadata {
     pub size: u64,
     pub blocks: u64,
     pub block_size: u32,
-    // todo: actually we want the WHOLE merkle tree (for random / streaming access, in the future)
+    // this is always a full power-of-two list of leaves in memory, we
+    // serialize only the non-empty ones (and re-do the empty leaf
+    // hashes after loading)
     pub merkle_leaves: Vec<[u8; 32]>,
     pub ciphertext_root: [u8; 32], // merkle root of the ciphertext blocks
 
@@ -980,7 +982,7 @@ impl ImmutableMetadata {
         b.extend_from_slice(&self.blocks.to_be_bytes());
         b.extend_from_slice(&self.block_size.to_be_bytes());
         b.extend_from_slice(&self.ciphertext_root);
-        // todo: should we hash over the secret_metadata too?
+        // todo: should we hash over the secret_metadata too? (probably?)
     }
 
     pub fn write<T>(&self, writer: &mut T) -> Result<(), MagicCapError>
@@ -1065,6 +1067,9 @@ impl<'a> Immutable<'a> {
         reader.seek(std::io::SeekFrom::Start(metadata_offset))?;
         let metadata: ImmutableMetadata = rmp_serde::decode::from_read(&mut reader)?;
         let bs = metadata.block_size;
+
+        // todo: ideally we wouldn't store any of the "empty" merkle
+        // leaves on disk, and instead re-constitute them here ...
 
         // check that the leaves correspond to the root -- does
         // rmp_serde give us hook so that we can check on every load?

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -347,7 +347,7 @@ impl ImmutableVerifier for ImmutableVerifyCap {
 /// ```
 pub struct ImmutableReadCap {
     // "Read" adds on top of Verify: we always need to verify
-    verify: ImmutableVerifyCap,
+    pub verify: ImmutableVerifyCap, // is pub okay here?
 
     // AES in CTR / Counter mode, with IV == 0 to start (for first
     // block) with 16-byte key and 16-byte IV + blocks.  ...we

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -807,7 +807,6 @@ impl std::str::FromStr for ImmutableReadCap {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         ImmutableReadCap::try_from(s)
     }
-
 }
 
 fn vec_to_array<T, const BLOCKSIZE: usize>(v: Vec<T>) -> Result<[T; BLOCKSIZE], MagicCapError> {

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -695,7 +695,7 @@ impl ReadCap for ImmutableReadCap {
             let lh = TahoeLeaf::hash(&leaf);
             leaves.push(lh);
         }
-        fill_empty_merkle_leaves(&mut leaves);
+        //fill_empty_merkle_leaves(&mut leaves);
 
         let merkle_tree = MerkleTree::<TahoeInside>::from_leaves(&leaves);
         let merkle_root = merkle_tree.root().ok_or(MagicCapError::MerkleError())?;

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -106,7 +106,7 @@ use rs_merkle::{Hasher, MerkleTree};
 use serde::ser::Serialize;
 use sha2::Sha256;
 
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, trace};
 
 use std::convert::Into;
 use std::convert::TryInto;
@@ -507,6 +507,7 @@ where
         // 2. yes? -> encrypt it
         // 3. where do we put the ciphertext? need a writer
         // boring way
+        trace!("ImmutableBuilder::write: {} bytes", buf.len());
         self.this_block.write(buf)?;
         let mut local_written = 0;
         // if we have a non-full block of plaintext when done() is
@@ -526,7 +527,13 @@ where
             local_written += encrypted_block.len();
             self.ciphertext_bytes += encrypted_block.len();
         }
-        Ok(local_written)
+
+        // things like std::io::copy are grumpy if we don't report
+        // that we wrote everything .. semantically, this makes some
+        // sense: we _have_ dealt with all the bytes in "buf" so
+        // returning that number is valid.
+        Ok(buf.len())
+
         // todo: we're basically "just hosed" if anything errors in
         // here, right? should we mark ourselves as failed then?
     }
@@ -534,7 +541,9 @@ where
     fn flush(&mut self) -> std::io::Result<()> {
         // 1. can we honour this by writing "part of a block"
         // immediately (and then writing the rest when it comes in?)
-        todo!()
+        debug!("flush called");
+        //todo!()
+        Ok(())
     }
     // think: can "done()" be like "close()"??
 }

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -799,6 +799,8 @@ impl std::convert::TryFrom<&str> for ImmutableReadCap {
     }
 }
 
+// clap wants FromStr
+// https://docs.rs/clap/latest/clap/_cookbook/typed_derive/index.html
 impl std::str::FromStr for ImmutableReadCap {
     type Err = MagicCapError;
 

--- a/magic_cap/src/test.rs
+++ b/magic_cap/src/test.rs
@@ -20,7 +20,7 @@ fn doc_example_in_memory() {
         println!("Read Cap: {:?}", readcap);
 
         let verifycap: ImmutableVerifyCap = readcap.into();
-        if !verifycap.corresponds_to(&immutable) {
+        if !verifycap.corresponds_to(&immutable.metadata) {
             println!("Verify Cap does not match data");
         }
     }
@@ -51,7 +51,7 @@ fn doc_example_verify() {
         .try_into()
         .unwrap();
     let mut ciphertext = Immutable::read(File::open("../kitten.mcap").unwrap()).unwrap();
-    assert!(verifycap.corresponds_to(&ciphertext));
+    assert!(verifycap.corresponds_to(&ciphertext.metadata));
     verifycap.verify(&mut ciphertext).unwrap();
 }
 

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -10,7 +10,7 @@ use tracing_subscriber::FmtSubscriber;
 use std::path::PathBuf;
 use url::Url;
 
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, builder::*, ValueEnum};
 use tracing::{Level, debug, error};
 
 #[derive(Parser)]
@@ -38,7 +38,7 @@ struct Cli {
     #[arg(short, long, default_value_t = Level::INFO)]
     loglevel: Level,
     // todo: maybe promote --catalog up here?
-    // ("mcap reduce" doesn't use it, and not all "mcap debug" command swill, ...)
+    // ("mcap reduce" doesn't use it, and not all "mcap debug" commands will, ...)
     // maybe clap gives us a way to say "--catalog is illegal for ..."?
 }
 
@@ -95,37 +95,12 @@ enum Commands {
 
     #[command(about = "turn a Read Cap + ciphertext into plaintext")]
     Decrypt {
+        // this flatten is VERY IMPORTANT and took me days to discover.
+        #[command(flatten)]
+        ciphertext_loader: CiphertextLoad,
+
         // non-optional magic-cap string
         cap: String,
-
-        // todo: shae says we can put these in a group .. see
-        // https://stackoverflow.com/questions/76315540/how-do-i-require-one-of-the-two-clap-options/76315811#76315811
-        #[arg(
-            long,
-            value_name("PATH"),
-            env("MCAP_CATALOG"),
-            help("root directory of a ciphertext catalog")
-        )]
-        catalog: Option<PathBuf>,
-
-        #[arg(
-            long,
-            value_name("URL"),
-            env("MCAP_URL"),
-            help("root URL of a ciphertext catalog")
-        )]
-        catalog_url: Option<Url>,
-
-        #[arg(
-            short,
-            long,
-            value_name("FNAME"),
-            help("path to a .mcap ciphertext file")
-        )]
-        ciphertext: Option<PathBuf>,
-
-        #[arg(short, long, value_name("URL"), help("url of the ciphertext file"))]
-        url: Option<Url>,
 
         #[arg(
             short,
@@ -174,6 +149,51 @@ enum Commands {
     },
 }
 
+
+/// When decrypting ciphertext, where is that ciphertext?
+/// Catalog or File?
+#[derive(Args, Clone)]
+#[group(required = true, multiple = true)]
+struct CiphertextLoad {
+    #[arg(
+        long,
+        value_name("PATH"),
+        env("MCAP_CATALOG"),
+        help("root directory of a ciphertext catalog"),
+    )]
+    local_catalog: Option<PathBuf>,
+
+    #[arg(
+        long,
+        value_name("URL"),
+        env("MCAP_URL"),
+        help("root URL of a ciphertext catalog")
+    )]
+    url_catalog: Option<Url>,
+
+    #[arg(
+        short,
+        long,
+        value_name("FNAME"),
+        help("path to a .mcap ciphertext file"),
+    )]
+    local_file: Option<PathBuf>,
+
+    #[arg(short, long, value_name("URL"), help("url of the ciphertext file"))]
+    url_file: Option<Url>,
+}
+
+/// When encrypting, where does the output go?
+/// Catalog, File, or both?
+#[derive(Args,Clone,Debug)]
+#[group(multiple = true)]
+struct CiphertextStore {
+    // index in a catalog
+    catalog: Option<PathBuf>,
+    // write to an output file
+    file: Option<PathBuf>,
+}
+
 fn main() {
     let cli = Cli::parse();
     // This will show TRACE, DEBUG, INFO, WARN and ERROR; see tokio's tracing examples
@@ -202,20 +222,20 @@ fn main() {
         ),
         Some(Commands::Decrypt {
             cap,
-            catalog,
-            catalog_url,
-            ciphertext,
-            url,
+            ciphertext_loader: ciphertext_load,
             plaintext,
-        }) => main_decrypt(
-            &mut std::io::stdout(),
-            cap,
-            catalog,
-            catalog_url,
-            ciphertext,
-            url,
-            plaintext,
-        ),
+        }) => {
+            let cl = ciphertext_load;
+            main_decrypt(
+                &mut std::io::stdout(),
+                cap,
+                &cl.local_catalog,
+                &cl.url_catalog,
+                &cl.local_file,
+                &cl.url_file,
+                plaintext,
+            )
+        }
         Some(Commands::Verify { cap, ciphertext }) => main_verify(cap, ciphertext),
         Some(Commands::Reduce { cap }) => main_reduce(&mut std::io::stdout(), cap),
         Some(Commands::Publish { catalog, output }) => {

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -170,7 +170,7 @@ fn main() {
             catalog,
             blocksize,
         }) => main_encrypt(
-            &mut std::io::stderr(),
+            &mut std::io::stdout(),
             plaintext,
             ciphertext,
             catalog,

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -174,7 +174,7 @@ struct CiphertextLoad {
         value_name("FNAME"),
         help("path to a .mcap ciphertext file")
     )]
-    local_file: Option<PathBuf>,
+    local_file: Vec<PathBuf>,
 
     #[arg(short, long, value_name("URL"), help("url of the ciphertext file"))]
     url_file: Option<Url>,

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -225,7 +225,6 @@ fn main() {
         }) => {
             let cl = ciphertext_load;
             main_decrypt(
-                &mut std::io::stdout(),
                 cap,
                 &cl.local_catalog,
                 &cl.url_catalog,

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -177,7 +177,7 @@ struct CiphertextLoad {
     local_file: Vec<PathBuf>,
 
     #[arg(short, long, value_name("URL"), help("url of the ciphertext file"))]
-    url_file: Option<Url>,
+    url_file: Vec<Url>,
 }
 
 /// When encrypting, where does the output go?

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -158,7 +158,7 @@ struct CiphertextLoad {
         env("MCAP_CATALOG"),
         help("root directory of a ciphertext catalog")
     )]
-    local_catalog: Option<PathBuf>,
+    local_catalog: Vec<PathBuf>,
 
     #[arg(
         long,
@@ -166,7 +166,7 @@ struct CiphertextLoad {
         env("MCAP_URL"),
         help("root URL of a ciphertext catalog")
     )]
-    url_catalog: Option<Url>,
+    url_catalog: Vec<Url>,
 
     #[arg(
         short,

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -147,7 +147,6 @@ enum Commands {
     },
 }
 
-
 /// When decrypting ciphertext, where is that ciphertext?
 /// Catalog or File?
 #[derive(Args, Clone)]
@@ -157,7 +156,7 @@ struct CiphertextLoad {
         long,
         value_name("PATH"),
         env("MCAP_CATALOG"),
-        help("root directory of a ciphertext catalog"),
+        help("root directory of a ciphertext catalog")
     )]
     local_catalog: Option<PathBuf>,
 
@@ -173,7 +172,7 @@ struct CiphertextLoad {
         short,
         long,
         value_name("FNAME"),
-        help("path to a .mcap ciphertext file"),
+        help("path to a .mcap ciphertext file")
     )]
     local_file: Option<PathBuf>,
 
@@ -183,7 +182,7 @@ struct CiphertextLoad {
 
 /// When encrypting, where does the output go?
 /// Catalog, File, or both?
-#[derive(Args,Clone,Debug)]
+#[derive(Args, Clone, Debug)]
 #[group(multiple = true)]
 struct CiphertextStore {
     // index in a catalog

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -1,3 +1,4 @@
+use magic_cap::ImmutableReadCap;
 use magic_cap_cli::{
     main_anthology_create, main_anthology_list, main_debug_info, main_debug_locator, main_decrypt,
     main_encrypt, main_publish, main_reduce, main_verify,
@@ -97,7 +98,7 @@ enum Commands {
         ciphertext_loader: CiphertextLoad,
 
         // non-optional magic-cap string
-        cap: String,
+        cap: ImmutableReadCap,
 
         #[arg(
             short,

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -10,7 +10,7 @@ use tracing_subscriber::FmtSubscriber;
 use std::path::PathBuf;
 use url::Url;
 
-use clap::{Args, Parser, Subcommand, builder::*, ValueEnum};
+use clap::{Args, Parser, Subcommand};
 use tracing::{Level, debug, error};
 
 #[derive(Parser)]
@@ -83,11 +83,8 @@ enum Commands {
         // non-optional source of data
         plaintext: PathBuf,
 
-        #[arg(short, long)]
-        ciphertext: Option<PathBuf>,
-
-        #[arg(long)]
-        catalog: Option<PathBuf>,
+        #[command(flatten)]
+        ciphertext_store: CiphertextStore,
 
         #[arg(short, long, default_value_t = 4096)]
         blocksize: usize, // not Option because we have a default value
@@ -189,9 +186,11 @@ struct CiphertextLoad {
 #[group(multiple = true)]
 struct CiphertextStore {
     // index in a catalog
+    #[arg(long)]
     catalog: Option<PathBuf>,
-    // write to an output file
-    file: Option<PathBuf>,
+    // write to a local file
+    #[arg(short, long)]
+    output_file: Option<PathBuf>,
 }
 
 fn main() {
@@ -210,14 +209,13 @@ fn main() {
         // we write the mcap string to stderr
         Some(Commands::Encrypt {
             plaintext,
-            ciphertext,
-            catalog,
+            ciphertext_store,
             blocksize,
         }) => main_encrypt(
             &mut std::io::stdout(),
             plaintext,
-            ciphertext,
-            catalog,
+            &ciphertext_store.output_file,
+            &ciphertext_store.catalog,
             *blocksize,
         ),
         Some(Commands::Decrypt {

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -1,6 +1,6 @@
 use magic_cap_cli::{
     main_debug_info, main_debug_locator, main_decrypt, main_encrypt, main_publish, main_reduce,
-    main_verify,
+    main_verify, main_anthology_create, main_anthology_list
 };
 use tracing_subscriber::FmtSubscriber;
 
@@ -55,6 +55,29 @@ enum DebugCommands {
 
         capstr: String,
     },
+}
+
+#[derive(Subcommand)]
+#[command(arg_required_else_help(true))]
+enum AnthologyCommands {
+    #[command(about = "Create a new Anthology into a (possibly existing) Catalog")]
+    Create {
+        directory: PathBuf,
+    },
+
+    #[command(about = "List the contents of an Anthology")]
+    List {
+        capstr: String,
+    },
+
+    // talked about having a "anthology download" or similar that will
+    // take an anthology and download it locally -- but probably wants
+    // more thinking? Like maybe this is a good idea for anything or
+    // any collection of Read Caps you have?
+    //#[command(about = "")]
+    //Download {
+    //    directory: PathBuf,
+    //},
 }
 
 #[derive(Subcommand)]
@@ -148,6 +171,14 @@ enum Commands {
         #[command(subcommand)]
         command: Option<DebugCommands>,
     },
+
+    #[command(
+        about = "Tools to create and manipulate Anthologies"
+    )]
+    Anthology {
+        #[command(subcommand)]
+        command: Option<AnthologyCommands>,
+    },
 }
 
 fn main() {
@@ -201,6 +232,11 @@ fn main() {
         Some(Commands::Debug { command }) => match command {
             Some(DebugCommands::Locator { capstr }) => main_debug_locator(capstr),
             Some(DebugCommands::Info { capstr, catalog }) => main_debug_info(capstr, catalog),
+            None => Ok(()),
+        },
+        Some(Commands::Anthology { command }) => match command {
+            Some(AnthologyCommands::Create{ directory }) => main_anthology_create(directory),
+            Some(AnthologyCommands::List{ capstr }) => main_anthology_list(capstr),
             None => Ok(()),
         },
         None => Ok(()),

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -1,6 +1,6 @@
 use magic_cap_cli::{
-    main_debug_info, main_debug_locator, main_decrypt, main_encrypt, main_publish, main_reduce,
-    main_verify, main_anthology_create, main_anthology_list
+    main_anthology_create, main_anthology_list, main_debug_info, main_debug_locator, main_decrypt,
+    main_encrypt, main_publish, main_reduce, main_verify,
 };
 use tracing_subscriber::FmtSubscriber;
 
@@ -61,15 +61,10 @@ enum DebugCommands {
 #[command(arg_required_else_help(true))]
 enum AnthologyCommands {
     #[command(about = "Create a new Anthology into a (possibly existing) Catalog")]
-    Create {
-        directory: PathBuf,
-    },
+    Create { directory: PathBuf },
 
     #[command(about = "List the contents of an Anthology")]
-    List {
-        capstr: String,
-    },
-
+    List { capstr: String },
     // talked about having a "anthology download" or similar that will
     // take an anthology and download it locally -- but probably wants
     // more thinking? Like maybe this is a good idea for anything or
@@ -172,9 +167,7 @@ enum Commands {
         command: Option<DebugCommands>,
     },
 
-    #[command(
-        about = "Tools to create and manipulate Anthologies"
-    )]
+    #[command(about = "Tools to create and manipulate Anthologies")]
     Anthology {
         #[command(subcommand)]
         command: Option<AnthologyCommands>,
@@ -235,8 +228,8 @@ fn main() {
             None => Ok(()),
         },
         Some(Commands::Anthology { command }) => match command {
-            Some(AnthologyCommands::Create{ directory }) => main_anthology_create(directory),
-            Some(AnthologyCommands::List{ capstr }) => main_anthology_list(capstr),
+            Some(AnthologyCommands::Create { directory }) => main_anthology_create(directory),
+            Some(AnthologyCommands::List { capstr }) => main_anthology_list(capstr),
             None => Ok(()),
         },
         None => Ok(()),

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -199,7 +199,7 @@ pub fn main_encrypt(
 
 /// "mcap decrypt"
 pub fn main_decrypt(
-    //    input: &mut impl Read,
+    // TODO: why do we pass in stdout here?
     output: &mut impl Write,
     cap: &ImmutableReadCap,
     catalog: &Option<PathBuf>,
@@ -219,76 +219,20 @@ pub fn main_decrypt(
         // so we can only do one
         todo!();
     }
-    // let cap = ImmutableReadCap::try_from(cap)?;
 
     if let Some(url) = input_url {
-        let mut headers = HeaderMap::new();
-        // read the last 8 bytes to get the metadata offset
-        headers.insert("Range", "bytes=-8".parse().unwrap());
-        let result = reqwest::blocking::Client::new()
-            .get(url.clone())
-            .headers(headers)
-            .send();
-
-        if let Ok(result) = result {
-            debug!("{:?}", result);
-            let offset = result.bytes()?;
-            let offraw: Vec<u8> = offset.into();
-            let offslice: [u8; 8] = offraw.try_into().unwrap();
-            let off: u64 = u64::from_be_bytes(offslice);
-            debug!("bytes {:?} {:?}", offslice, off);
-
-            // request the metadata bytes (note that we're also
-            // reading the last-8-bytes but serde ignores that
-            // successfully)
-            headers = HeaderMap::new();
-            headers.insert("Range", format!("bytes={}-", off).parse().unwrap());
-
-            let result = reqwest::blocking::Client::new()
-                .get(url.clone())
-                .headers(headers)
-                .send()?;
-            debug!("{:?}", result);
-            let metadata_raw: Vec<u8> = result.bytes()?.into();
-            debug!("{} bytes", metadata_raw.len());
-            let mut mdbytes = metadata_raw.as_slice();
-            let metadata: ImmutableMetadata = rmp_serde::decode::from_read(&mut mdbytes)?;
-            debug!(
-                "size={} blocks={} block_size={}",
-                metadata.size, metadata.blocks, metadata.block_size
-            );
-
-            // now we request 'all the rest of the bytes' and stream
-            // them into the decryptor (which will write to the output
-            // Write-able)
-            let mut output = std::io::stdout().lock();
-            let mut decryptor = cap.decrypt_stream(metadata, &mut output)?;
-
-            // skip the first 8 bytes, which are "mcap" + 32-byte version
-            // TODO: check those (version == 1 is the only one)
-            headers = HeaderMap::new();
-            headers.insert("Range", format!("bytes=8-{}", off).parse().unwrap());
-            let mut result = reqwest::blocking::Client::new()
-                .get(url.clone())
-                .headers(headers)
-                .send()
-                .unwrap();
-            // streams the incoming data to the decryptor object
-            result.copy_to(&mut decryptor)?;
-            return Ok(());
-        }
+        // now we request 'all the rest of the bytes' and stream
+        // them into the decryptor (which will write to the output
+        // Write-able)
+        InputUrl { url: url.clone() }.extract(cap.clone(), output)?
     }
 
-    // TODO FIXME early return
     if let Some(root_url) = catalog_url {
-        let collect = ImmutableWebCatalog::create(root_url.clone())?;
-        let locid: ImmutableIdentifier = cap.into();
-        let mut output = std::io::stdout().lock();
-        let metadata = collect.fetch_metadata(&locid)?;
-        let key = cap.create_tahoe_key();
-        let mut pusher = collect.stream_push(key, metadata, &mut output)?;
-        collect.copy_ciphertext_to(&locid, &mut pusher)?;
-        return Ok(());
+        // let mut output = std::io::stdout().lock();
+        CatalogUrl {
+            catalog_url: root_url.clone(),
+        }
+        .extract(cap.clone(), output)?
     }
 
     let immutable = if let Some(input_fname) = input_fname {
@@ -305,29 +249,39 @@ pub fn main_decrypt(
         ))
     };
 
+    if let Some(outfile) = outfile {
+        let mut output = std::fs::File::create(outfile)?;
+        // cap_match(&mut output, cap, outfile, immutable)
+        cap_match(&mut output, cap, immutable)
+        // out.write_all(plain.as_slice())?;
+        // match outfile.to_str() {
+        //     Some(of) => {
+        //         writeln!(
+        //             output,
+        //             "Wrote {} bytes of plaintext to \"{}\".",
+        //             plain.len(),
+        //             of,
+        //         )?;
+        //         Ok(())
+        //     }
+        //     None => Ok(()),
+        // }
+    } else {
+        let mut output = std::io::stdout();
+        // cap_match(&mut output, cap, outfile, immutable)
+        cap_match(&mut output, cap, immutable)
+        // out.write_all(plain.as_slice())?;
+    }
+}
+
+fn cap_match(
+    output: &mut impl Write,
+    cap: &ImmutableReadCap,
+    // outfile: &Option<PathBuf>,
+    immutable: Result<Immutable<'_>, MagicCapError>,
+) -> Result<(), MagicCapError> {
     match cap.decrypt(&mut immutable?) {
-        Ok(plain) => {
-            if let Some(outfile) = outfile {
-                let mut out = std::fs::File::create(outfile)?;
-                out.write_all(plain.as_slice())?;
-                match outfile.to_str() {
-                    Some(of) => {
-                        writeln!(
-                            output,
-                            "Wrote {} bytes of plaintext to \"{}\".",
-                            plain.len(),
-                            of,
-                        )?;
-                        Ok(())
-                    }
-                    None => Ok(()),
-                }
-            } else {
-                let mut out = std::io::stdout();
-                out.write_all(plain.as_slice())?;
-                Ok(())
-            }
-        }
+        Ok(plain) => Ok(output.write_all(plain.as_slice())?),
         Err(e) => match &e {
             MagicCapError::McapMetadataDiscordant() => Err(e),
             _ => {
@@ -581,4 +535,111 @@ pub fn main_anthology_list(capstr: &str) -> Result<(), MagicCapError> {
     }
 
     Ok(())
+}
+
+struct InputUrl {
+    url: Url,
+}
+struct CatalogUrl {
+    catalog_url: Url,
+}
+struct InputFile {
+    input_file: PathBuf,
+}
+
+pub trait Locator {
+    fn extract(
+        &self,
+        readcap: ImmutableReadCap,
+        output: &mut impl Write,
+    ) -> Result<(), MagicCapError>;
+}
+
+impl Locator for InputUrl {
+    fn extract(
+        &self,
+        readcap: ImmutableReadCap,
+        mut output: &mut impl Write,
+    ) -> Result<(), MagicCapError> {
+        let mut headers = HeaderMap::new();
+        // read the last 8 bytes to get the metadata offset
+        headers.insert("Range", "bytes=-8".parse().unwrap());
+        let result = reqwest::blocking::Client::new()
+            .get(self.url.clone())
+            .headers(headers)
+            .send()?;
+
+        debug!("{:?}", result);
+        let offset = result.bytes()?;
+        let offraw: Vec<u8> = offset.into();
+        let offslice: [u8; 8] = offraw.try_into().unwrap();
+        let off: u64 = u64::from_be_bytes(offslice);
+        debug!("bytes {:?} {:?}", offslice, off);
+
+        // request the metadata bytes (note that we're also
+        // reading the last-8-bytes but serde ignores that
+        // successfully)
+        headers = HeaderMap::new();
+        headers.insert("Range", format!("bytes={}-", off).parse().unwrap());
+
+        let result = reqwest::blocking::Client::new()
+            .get(self.url.clone())
+            .headers(headers)
+            .send()?;
+        debug!("{:?}", result);
+        let metadata_raw: Vec<u8> = result.bytes()?.into();
+        debug!("{} bytes", metadata_raw.len());
+        let mut mdbytes = metadata_raw.as_slice();
+        let metadata: ImmutableMetadata = rmp_serde::decode::from_read(&mut mdbytes)?;
+        debug!(
+            "size={} blocks={} block_size={}",
+            metadata.size, metadata.blocks, metadata.block_size
+        );
+
+        let mut decryptor = readcap.decrypt_stream(metadata, &mut output)?;
+
+        // skip the first 8 bytes, which are "mcap" + 32-byte version
+        // TODO: check those (version == 1 is the only one)
+        headers = HeaderMap::new();
+        headers.insert("Range", format!("bytes=8-{}", off).parse().unwrap());
+        let mut result = reqwest::blocking::Client::new()
+            .get(self.url.clone())
+            .headers(headers)
+            .send()
+            .unwrap();
+        // streams the incoming data to the decryptor object
+        result.copy_to(&mut decryptor)?;
+        Ok(())
+    }
+}
+
+impl Locator for CatalogUrl {
+    fn extract(
+        &self,
+        readcap: ImmutableReadCap,
+        output: &mut impl Write,
+    ) -> Result<(), MagicCapError> {
+        let collect = ImmutableWebCatalog::create(self.catalog_url.clone())?;
+        let tahoe_cap = readcap.clone();
+        let locid: ImmutableIdentifier = readcap.into();
+        let metadata = collect.fetch_metadata(&locid)?;
+        let key = tahoe_cap.create_tahoe_key();
+        let mut pusher = collect.stream_push(key, metadata, output)?;
+        collect.copy_ciphertext_to(&locid, &mut pusher)?;
+        Ok(())
+    }
+}
+
+impl Locator for InputFile {
+    fn extract(
+        &self,
+        readcap: ImmutableReadCap,
+        output: &mut impl Write,
+    ) -> Result<(), MagicCapError> {
+        let f = std::fs::File::open(self.input_file.clone())?;
+        let immutable = Immutable::read(&mut std::io::BufReader::new(f));
+
+        // cap_match(output, &readcap, outfile, immutable)
+        cap_match(output, &readcap, immutable)
+    }
 }

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -96,7 +96,7 @@
 //! ```
 //!
 
-use tracing::{debug};
+use tracing::debug;
 
 use magic_cap::err::MagicCapError;
 /// Functions that implement the core CLI commands
@@ -496,7 +496,6 @@ pub fn main_debug_info(capstr: &str, catalog: &Option<PathBuf>) -> Result<(), Ma
     Ok(())
 }
 
-
 pub struct AnthologyEntry {
     name: String,
     cap: ImmutableReadCap,
@@ -505,14 +504,15 @@ pub struct AnthologyEntry {
 //todo: something like?
 //pub fn create_anthology(entries: Vec<AnthologyEntry>) -> Result<dyn Read>;
 
-
 /// "mcap anthology create"
 pub fn main_anthology_create(directory: &PathBuf) -> Result<(), MagicCapError> {
     // need a catalog -- waiting for shapr's PR to "promote" it to top-level
     let mut catalog = ImmutableDirectoryCatalog::create(PathBuf::from("data/root"))?;
 
-    if ! directory.is_dir() {
-        return Err(MagicCapError::GenericError("Anthology is not a directory".to_string()));
+    if !directory.is_dir() {
+        return Err(MagicCapError::GenericError(
+            "Anthology is not a directory".to_string(),
+        ));
     }
 
     // refactor into own function
@@ -526,13 +526,14 @@ pub fn main_anthology_create(directory: &PathBuf) -> Result<(), MagicCapError> {
                 let mut builder = catalog.insert(4096).expect("Creating catalog entry");
                 let mut path: std::path::PathBuf = directory.clone();
                 path.push(p.file_name());
-                let mut plaintext = std::io::BufReader::new(std::fs::File::open(path.clone()).unwrap());
+                let mut plaintext =
+                    std::io::BufReader::new(std::fs::File::open(path.clone()).unwrap());
                 let written = std::io::copy(&mut plaintext, &mut builder).expect("Copy failed");
                 let (cap, _) = builder.done().expect("Failed to finalize Immutable");
                 eprintln!("{}: {} bytes", path.display(), written);
                 anthology.push(AnthologyEntry {
                     name: format!("{}", p.file_name().display()),
-                    cap
+                    cap,
                 });
             }
         }
@@ -543,7 +544,9 @@ pub fn main_anthology_create(directory: &PathBuf) -> Result<(), MagicCapError> {
     }
 
     // refactor into its own function, probably
-    let mut builder = catalog.insert(4096).expect("Create catalog anthology entry");
+    let mut builder = catalog
+        .insert(4096)
+        .expect("Create catalog anthology entry");
     for entry in anthology {
         writeln!(builder, "{} {}", entry.cap, entry.name).expect("Writing anthology entry");
     }
@@ -568,7 +571,9 @@ pub fn main_anthology_list(capstr: &str) -> Result<(), MagicCapError> {
             debug!("{:?}", line);
             let two: Vec<&str> = line.split(" ").collect();
             if two.len() != 2 {
-                return Err(MagicCapError::GenericError("illegal line in Anthology".to_string()));
+                return Err(MagicCapError::GenericError(
+                    "illegal line in Anthology".to_string(),
+                ));
             }
             let name = two[1];
             println!("{}", name);

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -223,10 +223,18 @@ pub fn main_decrypt(
 
     if !catalog_url.is_empty() {
         for this_url_catalog in catalog_url {
-            CatalogUrl {
+            let this_result = CatalogUrl {
                 catalog_url: this_url_catalog.clone(),
             }
-            .extract(cap, &mut output)?
+            .extract(cap, &mut output);
+            match this_result {
+                Ok(done) => return Ok(done),
+                Err(err) => match err {
+                    // the file was not found for this catalog, keep going!
+                    MagicCapError::ReqwestError(_error) => continue,
+                    _ => panic!("Something bad happened trying to find your file in a web catalog {err}"),
+                },
+            }
         }
     }
 
@@ -252,7 +260,6 @@ pub fn main_decrypt(
 fn cap_match(
     output: &mut impl Write,
     cap: &ImmutableReadCap,
-    // outfile: &Option<PathBuf>,
     immutable: Result<Immutable<'_>, MagicCapError>,
 ) -> Result<(), MagicCapError> {
     match cap.decrypt(&mut immutable?) {
@@ -597,11 +604,15 @@ impl Locator for CatalogUrl {
         readcap: &ImmutableReadCap,
         output: &mut impl Write,
     ) -> Result<(), MagicCapError> {
+        debug!("before catalog create");
         let collect = ImmutableWebCatalog::create(self.catalog_url.clone())?;
         let tahoe_cap = readcap.clone();
+        debug!("before readcap.into");
         let locid: ImmutableIdentifier = readcap.into();
+        debug!("before fetch_metadata");
         let metadata = collect.fetch_metadata(&locid)?;
         let key = tahoe_cap.create_tahoe_key();
+        debug!("before stream_push");
         let mut pusher = collect.stream_push(key, metadata, output)?;
         collect.copy_ciphertext_to(&locid, &mut pusher)?;
         Ok(())
@@ -617,7 +628,6 @@ impl Locator for FileLocal {
         let f = std::fs::File::open(self.file_local.clone())?;
         let immutable = Immutable::read(&mut std::io::BufReader::new(f));
 
-        // cap_match(output, &readcap, outfile, immutable)
         cap_match(output, readcap, immutable)
     }
 }

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -293,7 +293,9 @@ pub fn main_decrypt(
     }
 
     let count_sources = catalog_local.len() + catalog_url.len() + file_local.len() + file_url.len();
-    println!("Searched {count_sources} sources and did not find matching encrypted data to decrypt.");
+    println!(
+        "Searched {count_sources} sources and did not find matching encrypted data to decrypt."
+    );
     Ok(())
 }
 

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -207,7 +207,12 @@ pub fn main_decrypt(
     outfile: &Option<PathBuf>,
 ) -> Result<(), MagicCapError> {
     // decrypt to a file or stdout?
-    let mut output: Box<dyn Write> = ugly_wrapper(outfile);
+    let mut output: Box<dyn Write> = if let Some(output_file) = outfile {
+            debug!("creating output_file {:?}", output_file);
+            Box::new(std::fs::File::create(output_file).unwrap()) as Box<dyn Write>
+        } else {
+            Box::new(std::io::stdout()) as Box<dyn Write>
+        };
 
     if let Some(url) = input_url {
         // now we request 'all the rest of the bytes' and stream
@@ -238,15 +243,6 @@ pub fn main_decrypt(
     }
 
     Ok(())
-}
-
-fn ugly_wrapper(maybe_output_file: &Option<PathBuf>) -> Box<dyn Write> {
-    if let Some(output_file) = maybe_output_file {
-        debug!("creating output_file {:?}", output_file);
-        Box::new(std::fs::File::create(output_file).unwrap()) as Box<dyn Write>
-    } else {
-        Box::new(std::io::stdout()) as Box<dyn Write>
-    }
 }
 
 fn cap_match(

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -202,7 +202,7 @@ pub fn main_decrypt(
     readcap: &ImmutableReadCap,
     catalog_local: &Vec<PathBuf>,
     catalog_url: &Vec<Url>,
-    file_local: &Option<PathBuf>,
+    file_local: &Vec<PathBuf>,
     file_url: &Option<Url>,
     outfile: &Option<PathBuf>,
 ) -> Result<(), MagicCapError> {
@@ -232,19 +232,33 @@ pub fn main_decrypt(
                 Err(err) => match err {
                     // the file was not found for this catalog, keep going!
                     MagicCapError::ReqwestError(_error) => continue,
-                    _ => panic!("Something bad happened trying to find your file in a web catalog {err}"),
+                    _ => panic!(
+                        "Something bad happened trying to find your file in a web catalog {err}"
+                    ),
                 },
             }
         }
     }
 
-    if let Some(file_local) = file_local {
-        FileLocal {
-            file_local: file_local.clone(),
+    if !file_local.is_empty() {
+        for this_file_local in file_local {
+        let this_result = FileLocal {
+            file_local: this_file_local.clone(),
         }
-        .extract(readcap, &mut output)?
-    }
+            .extract(readcap, &mut output);
+            match this_result {
+                Ok(done) => return Ok(done),
+                Err(err) => match err {
+                    // file not found
+                    MagicCapError::IOError(_error) => continue,
+                    // file found, but does not match the given readcap
+                    MagicCapError::McapMetadataDiscordant() => continue,
+                    _ => panic!("Something bad happened trying to find your file on the drive {this_file_local:?} {err}"),
 
+                },
+            }
+        }
+    }
     if !catalog_local.is_empty() {
         for this_local_catalog in catalog_local {
             let this_result = CatalogLocal {
@@ -255,7 +269,9 @@ pub fn main_decrypt(
                 Ok(done) => return Ok(done),
                 Err(err) => match err {
                     MagicCapError::IOError(_error) => continue,
-                    _ => panic!("something bad happened trying to find your file on the drive {this_local_catalog:?} {err}"),
+                    _ => panic!(
+                        "something bad happened trying to find your file on the drive {this_local_catalog:?} {err}"
+                    ),
                 },
             }
         }

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -208,23 +208,23 @@ pub fn main_decrypt(
     input_url: &Option<Url>,
     outfile: &Option<PathBuf>,
 ) -> Result<(), MagicCapError> {
+    // decrypt to a file or stdout?
+    let mut output: Box<dyn Write> = ugly_wrapper(outfile);
+
     if let Some(url) = input_url {
         // now we request 'all the rest of the bytes' and stream
         // them into the decryptor (which will write to the output
         // Write-able)
-        FileUrl { url: url.clone() }.extract(cap, output)?
+        FileUrl { url: url.clone() }.extract(cap, &mut output)?
     }
 
     if let Some(root_url) = catalog_url {
-        // let mut output = std::io::stdout().lock();
         CatalogUrl {
             catalog_url: root_url.clone(),
         }
-        .extract(cap, output)?
+        .extract(cap, &mut output)?
     }
 
-    // decrypt to a file or stdout?
-    let mut output = ugly_wrapper(outfile) as Box<dyn Write>;
 
     if let Some(file_local) = input_fname {
         FileLocal {
@@ -245,6 +245,7 @@ pub fn main_decrypt(
 
 fn ugly_wrapper(maybe_output_file: &Option<PathBuf>) -> Box<dyn Write> {
     if let Some(output_file) = maybe_output_file {
+        debug!("creating output_file {:?}",output_file);
         Box::new(std::fs::File::create(output_file).unwrap()) as Box<dyn Write>
     } else {
         Box::new(std::io::stdout()) as Box<dyn Write>

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -199,11 +199,11 @@ pub fn main_encrypt(
 
 /// "mcap decrypt"
 pub fn main_decrypt(
-    cap: &ImmutableReadCap,
-    catalog: &Vec<PathBuf>,
+    readcap: &ImmutableReadCap,
+    catalog_local: &Vec<PathBuf>,
     catalog_url: &Vec<Url>,
-    input_fname: &Option<PathBuf>,
-    input_url: &Option<Url>,
+    file_local: &Option<PathBuf>,
+    file_url: &Option<Url>,
     outfile: &Option<PathBuf>,
 ) -> Result<(), MagicCapError> {
     // decrypt to a file or stdout?
@@ -214,11 +214,11 @@ pub fn main_decrypt(
         Box::new(std::io::stdout()) as Box<dyn Write>
     };
 
-    if let Some(url) = input_url {
+    if let Some(url) = file_url {
         // now we request 'all the rest of the bytes' and stream
         // them into the decryptor (which will write to the output
         // Write-able)
-        FileUrl { url: url.clone() }.extract(cap, &mut output)?
+        FileUrl { url: url.clone() }.extract(readcap, &mut output)?
     }
 
     if !catalog_url.is_empty() {
@@ -226,7 +226,7 @@ pub fn main_decrypt(
             let this_result = CatalogUrl {
                 catalog_url: this_url_catalog.clone(),
             }
-            .extract(cap, &mut output);
+            .extract(readcap, &mut output);
             match this_result {
                 Ok(done) => return Ok(done),
                 Err(err) => match err {
@@ -238,19 +238,26 @@ pub fn main_decrypt(
         }
     }
 
-    if let Some(file_local) = input_fname {
+    if let Some(file_local) = file_local {
         FileLocal {
             file_local: file_local.clone(),
         }
-        .extract(cap, &mut output)?
+        .extract(readcap, &mut output)?
     }
 
-    if !catalog.is_empty() {
-        for this_local_catalog in catalog {
-            CatalogLocal {
+    if !catalog_local.is_empty() {
+        for this_local_catalog in catalog_local {
+            let this_result = CatalogLocal {
                 catalog_local: this_local_catalog.to_path_buf(),
             }
-            .extract(cap, &mut output)?;
+            .extract(readcap, &mut output);
+            match this_result {
+                Ok(done) => return Ok(done),
+                Err(err) => match err {
+                    MagicCapError::IOError(_error) => continue,
+                    _ => panic!("something bad happened trying to find your file on the drive {this_local_catalog:?} {err}"),
+                },
+            }
         }
     }
 

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -203,7 +203,7 @@ pub fn main_decrypt(
     catalog_local: &Vec<PathBuf>,
     catalog_url: &Vec<Url>,
     file_local: &Vec<PathBuf>,
-    file_url: &Option<Url>,
+    file_url: &Vec<Url>,
     outfile: &Option<PathBuf>,
 ) -> Result<(), MagicCapError> {
     // decrypt to a file or stdout?
@@ -214,11 +214,20 @@ pub fn main_decrypt(
         Box::new(std::io::stdout()) as Box<dyn Write>
     };
 
-    if let Some(url) = file_url {
-        // now we request 'all the rest of the bytes' and stream
-        // them into the decryptor (which will write to the output
-        // Write-able)
-        FileUrl { url: url.clone() }.extract(readcap, &mut output)?
+    if !file_url.is_empty() {
+        for this_file_url in file_url {
+            let this_result = FileUrl {
+                url: this_file_url.clone(),
+            }
+            .extract(readcap, &mut output);
+            match this_result {
+                Ok(done) => return Ok(done),
+                Err(err) => match err {
+                    MagicCapError::McapMetadataDiscordant() => continue,
+                    _ => panic!("Something bad happened trying to decrypt your web file {err}"),
+                },
+            }
+        }
     }
 
     if !catalog_url.is_empty() {
@@ -242,9 +251,9 @@ pub fn main_decrypt(
 
     if !file_local.is_empty() {
         for this_file_local in file_local {
-        let this_result = FileLocal {
-            file_local: this_file_local.clone(),
-        }
+            let this_result = FileLocal {
+                file_local: this_file_local.clone(),
+            }
             .extract(readcap, &mut output);
             match this_result {
                 Ok(done) => return Ok(done),
@@ -253,8 +262,9 @@ pub fn main_decrypt(
                     MagicCapError::IOError(_error) => continue,
                     // file found, but does not match the given readcap
                     MagicCapError::McapMetadataDiscordant() => continue,
-                    _ => panic!("Something bad happened trying to find your file on the drive {this_file_local:?} {err}"),
-
+                    _ => panic!(
+                        "Something bad happened trying to find your file on the drive {this_file_local:?} {err}"
+                    ),
                 },
             }
         }
@@ -277,6 +287,7 @@ pub fn main_decrypt(
         }
     }
 
+    // XXX this needs to report zero files decrypted!
     Ok(())
 }
 
@@ -588,12 +599,13 @@ impl Locator for FileUrl {
         // reading the last-8-bytes but serde ignores that
         // successfully)
         headers = HeaderMap::new();
-        headers.insert("Range", format!("bytes={}-", off).parse().unwrap());
+        headers.insert("Range", format!("bytes={off}-").parse().unwrap());
 
         let result = reqwest::blocking::Client::new()
             .get(self.url.clone())
             .headers(headers)
-            .send()?;
+            .send()?
+            .error_for_status()?;
         debug!("{:?}", result);
         let metadata_raw: Vec<u8> = result.bytes()?.into();
         debug!("{} bytes", metadata_raw.len());
@@ -603,13 +615,16 @@ impl Locator for FileUrl {
             "size={} blocks={} block_size={}",
             metadata.size, metadata.blocks, metadata.block_size
         );
-
+        // does this readcap match this immutable?
+        if !readcap.verify.corresponds_to(&metadata) {
+            return Err(MagicCapError::McapMetadataDiscordant());
+        }
         let mut decryptor = readcap.decrypt_stream(metadata, &mut output)?;
 
         // skip the first 8 bytes, which are "mcap" + 32-byte version
         // TODO: check those (version == 1 is the only one)
         headers = HeaderMap::new();
-        headers.insert("Range", format!("bytes=8-{}", off).parse().unwrap());
+        headers.insert("Range", format!("bytes=8-{off}").parse().unwrap());
         let mut result = reqwest::blocking::Client::new()
             .get(self.url.clone())
             .headers(headers)

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -96,7 +96,7 @@
 //! ```
 //!
 
-use tracing::{debug, info};
+use tracing::{debug};
 
 use magic_cap::err::MagicCapError;
 /// Functions that implement the core CLI commands
@@ -297,7 +297,7 @@ pub fn main_decrypt(
     } else if let Some(root) = catalog {
         let collect = ImmutableDirectoryCatalog::create(root.clone())?;
         let locid: ImmutableIdentifier = (&cap).into();
-        info!("Loading location {}", locid);
+        debug!("Loading location {}", locid);
         collect.load(&locid)
     } else {
         Err(MagicCapError::GenericError(
@@ -502,43 +502,78 @@ pub struct AnthologyEntry {
     cap: ImmutableReadCap,
 }
 
+//todo: something like?
+//pub fn create_anthology(entries: Vec<AnthologyEntry>) -> Result<dyn Read>;
+
 
 /// "mcap anthology create"
 pub fn main_anthology_create(directory: &PathBuf) -> Result<(), MagicCapError> {
     // need a catalog -- waiting for shapr's PR to "promote" it to top-level
     let mut catalog = ImmutableDirectoryCatalog::create(PathBuf::from("data/root"))?;
 
-    debug!("{:?}", catalog);
+    if ! directory.is_dir() {
+        return Err(MagicCapError::GenericError("Anthology is not a directory".to_string()));
+    }
 
+    // refactor into own function
     let mut anthology: Vec<AnthologyEntry> = vec![];
 
-    if directory.is_dir() {
-        println!("okay");
-        for p in directory.read_dir().expect("Cannot list directory") {
-            if let Ok(p) = p {
-                let t = p.file_type().expect("Cannot stat file");
-                if t.is_file() {
-                    debug!("Encoding file {:?}", p.file_name());
-                    let mut builder = catalog.insert(4096).expect("Creating catalog entry");
-                    let mut path: std::path::PathBuf = directory.clone();
-                    path.push(p.file_name());
-                    let mut plaintext = std::io::BufReader::new(std::fs::File::open(path.clone()).unwrap());
-                    let w = std::io::copy(&mut plaintext, &mut builder).expect("Copy failed");
-                    println!("{}: {} bytes", path.display(), w);
-                    println!("{:?}", plaintext);
-                    let (cap, _) = builder.done().unwrap();
-                    anthology.push(AnthologyEntry {
-                        name: format!("{}", path.display()),
-                        cap
-                    });
-                }
+    for p in directory.read_dir().expect("Cannot list directory") {
+        if let Ok(p) = p {
+            let t = p.file_type().expect("Cannot stat file");
+            if t.is_file() {
+                debug!("Encoding file {:?}", p.file_name());
+                let mut builder = catalog.insert(4096).expect("Creating catalog entry");
+                let mut path: std::path::PathBuf = directory.clone();
+                path.push(p.file_name());
+                let mut plaintext = std::io::BufReader::new(std::fs::File::open(path.clone()).unwrap());
+                let written = std::io::copy(&mut plaintext, &mut builder).expect("Copy failed");
+                let (cap, _) = builder.done().expect("Failed to finalize Immutable");
+                println!("{}: {} bytes", path.display(), written);
+                anthology.push(AnthologyEntry {
+                    name: format!("{}", p.file_name().display()),
+                    cap
+                });
             }
         }
     }
 
+    if anthology.len() == 0 {
+        return Err(MagicCapError::GenericError("Empty Anthology".to_string()));
+    }
+
+    // refactor into its own function, probably
+    let mut builder = catalog.insert(4096).expect("Create catalog anthology entry");
+    for entry in anthology {
+        writeln!(builder, "{} {}", entry.cap, entry.name).expect("Writing anthology entry");
+    }
+    let (cap, _) = builder.done().expect("Failed to finalize Immutable");
+    println!("{}", cap);
+
     Ok(())
 }
 
-pub fn main_anthology_list(capstr: &String) -> Result<(), MagicCapError> {
-    todo!()
+pub fn main_anthology_list(capstr: &str) -> Result<(), MagicCapError> {
+    // need a catalog -- waiting for shapr's PR to "promote" it to top-level
+    let catalog = ImmutableDirectoryCatalog::create(PathBuf::from("data/root"))?;
+    let cap: ImmutableReadCap = capstr.try_into()?;
+
+    let id: ImmutableIdentifier = cap.clone().into();
+    let mut anthology = catalog.load(&id)?;
+    let plaintext = cap.decrypt(&mut anthology)?;
+
+    debug!("{:?}", anthology.metadata);
+    for line in plaintext.lines() {
+        if let Ok(line) = line {
+            debug!("{:?}", line);
+            let two: Vec<&str> = line.split(" ").collect();
+            if two.len() != 2 {
+                return Err(MagicCapError::GenericError("illegal line in Anthology".to_string()));
+            }
+            let name = two[1];
+            println!("{}", name);
+        }
+    }
+
+    Ok(())
 }

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -495,3 +495,50 @@ pub fn main_debug_info(capstr: &str, catalog: &Option<PathBuf>) -> Result<(), Ma
     }
     Ok(())
 }
+
+
+pub struct AnthologyEntry {
+    name: String,
+    cap: ImmutableReadCap,
+}
+
+
+/// "mcap anthology create"
+pub fn main_anthology_create(directory: &PathBuf) -> Result<(), MagicCapError> {
+    // need a catalog -- waiting for shapr's PR to "promote" it to top-level
+    let mut catalog = ImmutableDirectoryCatalog::create(PathBuf::from("data/root"))?;
+
+    debug!("{:?}", catalog);
+
+    let mut anthology: Vec<AnthologyEntry> = vec![];
+
+    if directory.is_dir() {
+        println!("okay");
+        for p in directory.read_dir().expect("Cannot list directory") {
+            if let Ok(p) = p {
+                let t = p.file_type().expect("Cannot stat file");
+                if t.is_file() {
+                    debug!("Encoding file {:?}", p.file_name());
+                    let mut builder = catalog.insert(4096).expect("Creating catalog entry");
+                    let mut path: std::path::PathBuf = directory.clone();
+                    path.push(p.file_name());
+                    let mut plaintext = std::io::BufReader::new(std::fs::File::open(path.clone()).unwrap());
+                    let w = std::io::copy(&mut plaintext, &mut builder).expect("Copy failed");
+                    println!("{}: {} bytes", path.display(), w);
+                    println!("{:?}", plaintext);
+                    let (cap, _) = builder.done().unwrap();
+                    anthology.push(AnthologyEntry {
+                        name: format!("{}", path.display()),
+                        cap
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub fn main_anthology_list(capstr: &String) -> Result<(), MagicCapError> {
+    todo!()
+}

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -529,7 +529,7 @@ pub fn main_anthology_create(directory: &PathBuf) -> Result<(), MagicCapError> {
                 let mut plaintext = std::io::BufReader::new(std::fs::File::open(path.clone()).unwrap());
                 let written = std::io::copy(&mut plaintext, &mut builder).expect("Copy failed");
                 let (cap, _) = builder.done().expect("Failed to finalize Immutable");
-                println!("{}: {} bytes", path.display(), written);
+                eprintln!("{}: {} bytes", path.display(), written);
                 anthology.push(AnthologyEntry {
                     name: format!("{}", p.file_name().display()),
                     cap

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -224,7 +224,7 @@ pub fn main_decrypt(
         // now we request 'all the rest of the bytes' and stream
         // them into the decryptor (which will write to the output
         // Write-able)
-        InputUrl { url: url.clone() }.extract(cap.clone(), output)?
+        FileUrl { url: url.clone() }.extract(&cap, output)?
     }
 
     if let Some(root_url) = catalog_url {
@@ -232,7 +232,7 @@ pub fn main_decrypt(
         CatalogUrl {
             catalog_url: root_url.clone(),
         }
-        .extract(cap.clone(), output)?
+        .extract(cap, output)?
     }
 
     let immutable = if let Some(input_fname) = input_fname {
@@ -249,11 +249,23 @@ pub fn main_decrypt(
         ))
     };
 
+    if let Some(file_local) = input_fname {
+        FileLocal {
+            file_local: file_local.clone(),
+        }
+        .extract(cap, output)?
+    }
+
+    if let Some(catalog_local) = catalog {
+        CatalogLocal{catalog_local: catalog_local.to_path_buf()}.extract(cap, output)?
+        // CatalogLocal
+    }
+
+    // decrypt to a file or stdout?
     if let Some(outfile) = outfile {
         let mut output = std::fs::File::create(outfile)?;
-        // cap_match(&mut output, cap, outfile, immutable)
+
         cap_match(&mut output, cap, immutable)
-        // out.write_all(plain.as_slice())?;
         // match outfile.to_str() {
         //     Some(of) => {
         //         writeln!(
@@ -537,28 +549,31 @@ pub fn main_anthology_list(capstr: &str) -> Result<(), MagicCapError> {
     Ok(())
 }
 
-struct InputUrl {
+struct FileUrl {
     url: Url,
 }
 struct CatalogUrl {
     catalog_url: Url,
 }
-struct InputFile {
-    input_file: PathBuf,
+struct FileLocal {
+    file_local: PathBuf,
+}
+struct CatalogLocal {
+    catalog_local: PathBuf,
 }
 
 pub trait Locator {
     fn extract(
         &self,
-        readcap: ImmutableReadCap,
+        readcap: &ImmutableReadCap,
         output: &mut impl Write,
     ) -> Result<(), MagicCapError>;
 }
 
-impl Locator for InputUrl {
+impl Locator for FileUrl {
     fn extract(
         &self,
-        readcap: ImmutableReadCap,
+        readcap: &ImmutableReadCap,
         mut output: &mut impl Write,
     ) -> Result<(), MagicCapError> {
         let mut headers = HeaderMap::new();
@@ -616,7 +631,7 @@ impl Locator for InputUrl {
 impl Locator for CatalogUrl {
     fn extract(
         &self,
-        readcap: ImmutableReadCap,
+        readcap: &ImmutableReadCap,
         output: &mut impl Write,
     ) -> Result<(), MagicCapError> {
         let collect = ImmutableWebCatalog::create(self.catalog_url.clone())?;
@@ -630,16 +645,29 @@ impl Locator for CatalogUrl {
     }
 }
 
-impl Locator for InputFile {
+impl Locator for FileLocal {
     fn extract(
         &self,
-        readcap: ImmutableReadCap,
+        readcap: &ImmutableReadCap,
         output: &mut impl Write,
     ) -> Result<(), MagicCapError> {
-        let f = std::fs::File::open(self.input_file.clone())?;
+        let f = std::fs::File::open(self.file_local.clone())?;
         let immutable = Immutable::read(&mut std::io::BufReader::new(f));
 
         // cap_match(output, &readcap, outfile, immutable)
+        cap_match(output, &readcap, immutable)
+    }
+}
+impl Locator for CatalogLocal {
+    fn extract(
+        &self,
+        readcap: &ImmutableReadCap,
+        output: &mut impl Write,
+    ) -> Result<(), MagicCapError> {
+                let collect = ImmutableDirectoryCatalog::create(self.catalog_local.clone())?;
+        let locid: ImmutableIdentifier = readcap.into();
+        debug!("Loading location {}", locid);
+        let immutable = collect.load(&locid);
         cap_match(output, &readcap, immutable)
     }
 }

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -201,7 +201,7 @@ pub fn main_encrypt(
 pub fn main_decrypt(
     //    input: &mut impl Read,
     output: &mut impl Write,
-    cap: &str,
+    cap: &ImmutableReadCap,
     catalog: &Option<PathBuf>,
     catalog_url: &Option<Url>,
     input_fname: &Option<PathBuf>,
@@ -219,7 +219,7 @@ pub fn main_decrypt(
         // so we can only do one
         todo!();
     }
-    let cap = ImmutableReadCap::try_from(cap)?;
+    // let cap = ImmutableReadCap::try_from(cap)?;
 
     if let Some(url) = input_url {
         let mut headers = HeaderMap::new();
@@ -282,7 +282,7 @@ pub fn main_decrypt(
     // TODO FIXME early return
     if let Some(root_url) = catalog_url {
         let collect = ImmutableWebCatalog::create(root_url.clone())?;
-        let locid: ImmutableIdentifier = (&cap).into();
+        let locid: ImmutableIdentifier = cap.into();
         let mut output = std::io::stdout().lock();
         let metadata = collect.fetch_metadata(&locid)?;
         let key = cap.create_tahoe_key();
@@ -296,7 +296,7 @@ pub fn main_decrypt(
         Immutable::read(&mut std::io::BufReader::new(f))
     } else if let Some(root) = catalog {
         let collect = ImmutableDirectoryCatalog::create(root.clone())?;
-        let locid: ImmutableIdentifier = (&cap).into();
+        let locid: ImmutableIdentifier = cap.into();
         debug!("Loading location {}", locid);
         collect.load(&locid)
     } else {

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -200,19 +200,19 @@ pub fn main_encrypt(
 /// "mcap decrypt"
 pub fn main_decrypt(
     cap: &ImmutableReadCap,
-    catalog: &Option<PathBuf>,
-    catalog_url: &Option<Url>,
+    catalog: &Vec<PathBuf>,
+    catalog_url: &Vec<Url>,
     input_fname: &Option<PathBuf>,
     input_url: &Option<Url>,
     outfile: &Option<PathBuf>,
 ) -> Result<(), MagicCapError> {
     // decrypt to a file or stdout?
     let mut output: Box<dyn Write> = if let Some(output_file) = outfile {
-            debug!("creating output_file {:?}", output_file);
-            Box::new(std::fs::File::create(output_file).unwrap()) as Box<dyn Write>
-        } else {
-            Box::new(std::io::stdout()) as Box<dyn Write>
-        };
+        debug!("creating output_file {:?}", output_file);
+        Box::new(std::fs::File::create(output_file).unwrap()) as Box<dyn Write>
+    } else {
+        Box::new(std::io::stdout()) as Box<dyn Write>
+    };
 
     if let Some(url) = input_url {
         // now we request 'all the rest of the bytes' and stream
@@ -221,11 +221,13 @@ pub fn main_decrypt(
         FileUrl { url: url.clone() }.extract(cap, &mut output)?
     }
 
-    if let Some(root_url) = catalog_url {
-        CatalogUrl {
-            catalog_url: root_url.clone(),
+    if !catalog_url.is_empty() {
+        for this_url_catalog in catalog_url {
+            CatalogUrl {
+                catalog_url: this_url_catalog.clone(),
+            }
+            .extract(cap, &mut output)?
         }
-        .extract(cap, &mut output)?
     }
 
     if let Some(file_local) = input_fname {
@@ -235,11 +237,13 @@ pub fn main_decrypt(
         .extract(cap, &mut output)?
     }
 
-    if let Some(catalog_local) = catalog {
-        CatalogLocal {
-            catalog_local: catalog_local.to_path_buf(),
+    if !catalog.is_empty() {
+        for this_local_catalog in catalog {
+            CatalogLocal {
+                catalog_local: this_local_catalog.to_path_buf(),
+            }
+            .extract(cap, &mut output)?;
         }
-        .extract(cap, &mut output)?;
     }
 
     Ok(())

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -198,6 +198,9 @@ pub fn main_encrypt(
 //static default_catalog: PathBuf = PathBuf::from("~/.magicap");
 
 /// "mcap decrypt"
+/// accepts one readcap 'decryption key', four vectors of sources for encrypted data, and an outfile Option.
+/// if outfile is None, write to standard output.
+/// if the vectors are not empty, search each of them in order for matching encrypted data.
 pub fn main_decrypt(
     readcap: &ImmutableReadCap,
     catalog_local: &Vec<PathBuf>,
@@ -214,6 +217,8 @@ pub fn main_decrypt(
         Box::new(std::io::stdout()) as Box<dyn Write>
     };
 
+    // these four separate pieces could likely be one single much shorter stanza!
+    // something like Vec<impl Locator>.map(|l|l.extract().unwrap_or_else(...)) ?
     if !file_url.is_empty() {
         for this_file_url in file_url {
             let this_result = FileUrl {
@@ -287,7 +292,8 @@ pub fn main_decrypt(
         }
     }
 
-    // XXX this needs to report zero files decrypted!
+    let count_sources = catalog_local.len() + catalog_url.len() + file_local.len() + file_url.len();
+    println!("Searched {count_sources} sources and did not find matching encrypted data to decrypt.");
     Ok(())
 }
 

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -199,8 +199,6 @@ pub fn main_encrypt(
 
 /// "mcap decrypt"
 pub fn main_decrypt(
-    // TODO: why do we pass in stdout here?
-    output: &mut impl Write,
     cap: &ImmutableReadCap,
     catalog: &Option<PathBuf>,
     catalog_url: &Option<Url>,
@@ -225,7 +223,6 @@ pub fn main_decrypt(
         .extract(cap, &mut output)?
     }
 
-
     if let Some(file_local) = input_fname {
         FileLocal {
             file_local: file_local.clone(),
@@ -245,7 +242,7 @@ pub fn main_decrypt(
 
 fn ugly_wrapper(maybe_output_file: &Option<PathBuf>) -> Box<dyn Write> {
     if let Some(output_file) = maybe_output_file {
-        debug!("creating output_file {:?}",output_file);
+        debug!("creating output_file {:?}", output_file);
         Box::new(std::fs::File::create(output_file).unwrap()) as Box<dyn Write>
     } else {
         Box::new(std::io::stdout()) as Box<dyn Write>

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -208,23 +208,11 @@ pub fn main_decrypt(
     input_url: &Option<Url>,
     outfile: &Option<PathBuf>,
 ) -> Result<(), MagicCapError> {
-    if input_fname.is_some() && input_url.is_some() {
-        todo!();
-        // similar to below, use type system to say "either PathBuf OR Url"
-    }
-    if catalog.is_some() && input_fname.is_some() {
-        // could be error, could say "if filename doesn't exist then use catalog"
-        //
-        // take a Enum in here that is a Catalog OR a input_fname OR catalog-url
-        // so we can only do one
-        todo!();
-    }
-
     if let Some(url) = input_url {
         // now we request 'all the rest of the bytes' and stream
         // them into the decryptor (which will write to the output
         // Write-able)
-        FileUrl { url: url.clone() }.extract(&cap, output)?
+        FileUrl { url: url.clone() }.extract(cap, output)?
     }
 
     if let Some(root_url) = catalog_url {
@@ -235,54 +223,31 @@ pub fn main_decrypt(
         .extract(cap, output)?
     }
 
-    let immutable = if let Some(input_fname) = input_fname {
-        let f = std::fs::File::open(input_fname)?;
-        Immutable::read(&mut std::io::BufReader::new(f))
-    } else if let Some(root) = catalog {
-        let collect = ImmutableDirectoryCatalog::create(root.clone())?;
-        let locid: ImmutableIdentifier = cap.into();
-        debug!("Loading location {}", locid);
-        collect.load(&locid)
-    } else {
-        Err(MagicCapError::GenericError(
-            "Must provide either --ciphertext or --catalog or --catalog-url".to_string(),
-        ))
-    };
+    // decrypt to a file or stdout?
+    let mut output = ugly_wrapper(outfile) as Box<dyn Write>;
 
     if let Some(file_local) = input_fname {
         FileLocal {
             file_local: file_local.clone(),
         }
-        .extract(cap, output)?
+        .extract(cap, &mut output)?
     }
 
     if let Some(catalog_local) = catalog {
-        CatalogLocal{catalog_local: catalog_local.to_path_buf()}.extract(cap, output)?
-        // CatalogLocal
+        CatalogLocal {
+            catalog_local: catalog_local.to_path_buf(),
+        }
+        .extract(cap, &mut output)?;
     }
 
-    // decrypt to a file or stdout?
-    if let Some(outfile) = outfile {
-        let mut output = std::fs::File::create(outfile)?;
+    Ok(())
+}
 
-        cap_match(&mut output, cap, immutable)
-        // match outfile.to_str() {
-        //     Some(of) => {
-        //         writeln!(
-        //             output,
-        //             "Wrote {} bytes of plaintext to \"{}\".",
-        //             plain.len(),
-        //             of,
-        //         )?;
-        //         Ok(())
-        //     }
-        //     None => Ok(()),
-        // }
+fn ugly_wrapper(maybe_output_file: &Option<PathBuf>) -> Box<dyn Write> {
+    if let Some(output_file) = maybe_output_file {
+        Box::new(std::fs::File::create(output_file).unwrap()) as Box<dyn Write>
     } else {
-        let mut output = std::io::stdout();
-        // cap_match(&mut output, cap, outfile, immutable)
-        cap_match(&mut output, cap, immutable)
-        // out.write_all(plain.as_slice())?;
+        Box::new(std::io::stdout()) as Box<dyn Write>
     }
 }
 
@@ -655,7 +620,7 @@ impl Locator for FileLocal {
         let immutable = Immutable::read(&mut std::io::BufReader::new(f));
 
         // cap_match(output, &readcap, outfile, immutable)
-        cap_match(output, &readcap, immutable)
+        cap_match(output, readcap, immutable)
     }
 }
 impl Locator for CatalogLocal {
@@ -664,10 +629,10 @@ impl Locator for CatalogLocal {
         readcap: &ImmutableReadCap,
         output: &mut impl Write,
     ) -> Result<(), MagicCapError> {
-                let collect = ImmutableDirectoryCatalog::create(self.catalog_local.clone())?;
+        let collect = ImmutableDirectoryCatalog::create(self.catalog_local.clone())?;
         let locid: ImmutableIdentifier = readcap.into();
         debug!("Loading location {}", locid);
         let immutable = collect.load(&locid);
-        cap_match(output, &readcap, immutable)
+        cap_match(output, readcap, immutable)
     }
 }

--- a/mcap/src/tests.rs
+++ b/mcap/src/tests.rs
@@ -1,10 +1,12 @@
 #[cfg(test)]
 pub mod test {
     use crate::{main_decrypt, main_encrypt, main_reduce, main_verify};
+    use magic_cap::ImmutableReadCap;
     use magic_cap::err::MagicCapError;
     use proptest::prelude::*;
     use std::fs::File;
     use std::io::{Read, Write};
+    use std::str::FromStr;
     use tempfile::tempdir;
 
     #[test]
@@ -53,7 +55,8 @@ pub mod test {
 
             // confirm that "decrypt" can turn back into plaintext
             let mut output = vec!();
-            main_decrypt(&mut output, capstr, &None, &None, &Some(cipher), &None, &Some(round.clone())).unwrap();
+            let immutable_read_cap = ImmutableReadCap::from_str(capstr).unwrap();
+            main_decrypt(&mut output, &immutable_read_cap, &None, &None, &Some(cipher), &None, &Some(round.clone())).unwrap();
 
             let mut og = String::new();
             let mut other = String::new();

--- a/mcap/src/tests.rs
+++ b/mcap/src/tests.rs
@@ -59,7 +59,7 @@ pub mod test {
             // confirm that "decrypt" can turn back into plaintext
             let immutable_read_cap = ImmutableReadCap::from_str(capstr).unwrap();
             // XXX why does this test pass? The println at the top certainly runs! Something is wrong here!
-            main_decrypt(&immutable_read_cap, &vec![], &vec![], &Some(cipher), &None, &Some(round.clone())).unwrap();
+            main_decrypt(&immutable_read_cap, &vec![], &vec![], &vec![cipher], &None, &Some(round.clone())).unwrap();
 
             let mut og = String::new();
             let mut other = String::new();

--- a/mcap/src/tests.rs
+++ b/mcap/src/tests.rs
@@ -59,7 +59,7 @@ pub mod test {
             // confirm that "decrypt" can turn back into plaintext
             let immutable_read_cap = ImmutableReadCap::from_str(capstr).unwrap();
             // XXX why does this test pass? The println at the top certainly runs! Something is wrong here!
-            main_decrypt(&immutable_read_cap, &vec![], &vec![], &vec![cipher], &None, &Some(round.clone())).unwrap();
+            main_decrypt(&immutable_read_cap, &vec![], &vec![], &vec![cipher], &vec![], &Some(round.clone())).unwrap();
 
             let mut og = String::new();
             let mut other = String::new();

--- a/mcap/src/tests.rs
+++ b/mcap/src/tests.rs
@@ -27,14 +27,17 @@ pub mod test {
 
     proptest! {
         #[test]
-        fn round_trip_main(s in "\\PC+") {
+        fn mcap_round_trip_main(s in "\\PC+") {
             // write to a file so we can exercise via paths
+            println!("we have reached the inside of mcap round_trip_main proptest");
             let outd = tempdir()?;
             let plain = outd.path().join("plain");
+            println!("creating plain file at {:?}",plain);
             {
                 let mut tmp = File::create(&plain)?;
                 tmp.write(s.as_bytes())?;
             }  // close tmp
+            println!("finished writing to tmp");
             let cipher = outd.path().join("cipher");
             let mut output = vec!();
             main_encrypt(&mut output, &plain, &Some(cipher.clone()), &None, 4096).unwrap();
@@ -54,13 +57,15 @@ pub mod test {
             assert_eq!(String::from_utf8(output).unwrap().trim(), verifycap);
 
             // confirm that "decrypt" can turn back into plaintext
-            let mut output = vec!();
             let immutable_read_cap = ImmutableReadCap::from_str(capstr).unwrap();
-            main_decrypt(&mut output, &immutable_read_cap, &None, &None, &Some(cipher), &None, &Some(round.clone())).unwrap();
+            // XXX why does this test pass? The println at the top certainly runs! Something is wrong here!
+            main_decrypt(&immutable_read_cap, &None, &None, &Some(cipher), &None, &Some(round.clone())).unwrap();
 
             let mut og = String::new();
             let mut other = String::new();
+            println!("opening plain to og");
             File::open(plain)?.read_to_string(&mut og)?;
+            println!("opening round to other");
             File::open(round)?.read_to_string(&mut other)?;
 
             assert_eq!(og, other);

--- a/mcap/src/tests.rs
+++ b/mcap/src/tests.rs
@@ -59,7 +59,7 @@ pub mod test {
             // confirm that "decrypt" can turn back into plaintext
             let immutable_read_cap = ImmutableReadCap::from_str(capstr).unwrap();
             // XXX why does this test pass? The println at the top certainly runs! Something is wrong here!
-            main_decrypt(&immutable_read_cap, &None, &None, &Some(cipher), &None, &Some(round.clone())).unwrap();
+            main_decrypt(&immutable_read_cap, &vec![], &vec![], &Some(cipher), &None, &Some(round.clone())).unwrap();
 
             let mut og = String::new();
             let mut other = String::new();


### PR DESCRIPTION
This PR allows `mcap decrypt` to accept and check any number of the four flavors of arguments:
- `--local-catalog`
- `--url-catalog`
- `--local-file`
- `--url-file`

Assuming a readcap arg is given, it will be checked against all the arguments.

This PR is built on top of #26 and is very nearly complete.

The original goal was to fix #24 and this happily also fixes #28

Another exciting feature is that readcap parsing happens in only one place in the command line handling code, and all functions now receive a genuine `ImmutableReadCap`.

Along the way, unified handling of `File` and `Stdout` was discovered by using `as Box<dyn Write>` to hold either of those in a trait typed value.

The reqwest result method `error_for_status` was used so 404 http responses for files or catalogs are handled correctly.

The `corresponds_to` method on the `ImmutableVerifyCap` type was simplified as it only needs the reacap and the metadata, rather than the entire Immutable value.
This last step was done to fix #28 as it was necessary to be able to continue checking other http file values.
```
Usage: mcap decrypt [OPTIONS] <--local-catalog <PATH>|--url-catalog <URL>|--local-file <FNAME>|--url-file <URL>> <CAP>

Arguments:
  <CAP>

Options:
      --local-catalog <PATH>  root directory of a ciphertext catalog [env: MCAP_CATALOG=]
      --url-catalog <URL>     root URL of a ciphertext catalog [env: MCAP_URL=]
  -l, --local-file <FNAME>    path to a .mcap ciphertext file
  -u, --url-file <URL>        url of the ciphertext file
  -p, --plaintext <FNAME>     path to write plaintext to (default: stdout)
  -h, --help                  Print help
```

WHAT'S MISSING?
- [x] If zero of the four values match the ReadCap, nothing happens. Users would be confused. The fall through case at the end should say "We tried all your cipher text locations and none of them matched the ReadCap you gave us."
- [ ] My end goal is for main_decrypt to accept `Vec<Locator>` but I don' t know if this is possible!