### PR TITLE
Trailing slash ugly hack fix

### DIFF
--- a/magic_cap/src/catalog.rs
+++ b/magic_cap/src/catalog.rs
@@ -130,7 +130,14 @@ impl ImmutableWebCatalog {
     pub fn create(root: Url) -> Result<ImmutableWebCatalog, MagicCapError> {
         debug!("start of ImmutableWebCatalog create");
         // figure out of this looks like a Magic Cap Catalog version 0 REST API
-        let url = root.clone();
+        // XXX ugly hack, convert Url to string, append '/' parse back to Url
+        let ugly_hack = root.as_str();
+        let mut hacked_url = String::new();
+        hacked_url.push_str(ugly_hack);
+        hacked_url.push('/');
+        // XXX end ugly_hack
+
+        let url = Url::parse(&hacked_url).expect("could not append trailing slash to url");
         let url = url.join("magic-cap-catalog").unwrap();
         debug!("url is {}", url);
         let result = reqwest::blocking::Client::new().get(url).send()?;

--- a/mcap/src/bin/mcap.rs
+++ b/mcap/src/bin/mcap.rs
@@ -47,14 +47,14 @@ struct Cli {
 #[command(arg_required_else_help(true))]
 enum DebugCommands {
     #[command(about = "Convert given Read Cap (or Verify Cap) to a Location-Id")]
-    Locator { capstr: String },
+    Locator { readcap: ImmutableReadCap },
 
     #[command(about = "Print human-readable information about the Read Cap")]
     Info {
         #[arg(long)]
         catalog: Option<PathBuf>,
 
-        capstr: String,
+        readcap: ImmutableReadCap,
     },
 }
 
@@ -65,7 +65,7 @@ enum AnthologyCommands {
     Create { directory: PathBuf },
 
     #[command(about = "List the contents of an Anthology")]
-    List { capstr: String },
+    List { readcap: ImmutableReadCap },
     // talked about having a "anthology download" or similar that will
     // take an anthology and download it locally -- but probably wants
     // more thinking? Like maybe this is a good idea for anything or
@@ -240,13 +240,16 @@ fn main() {
         }
         // todo: might make sense to promote --catalog to top-level
         Some(Commands::Debug { command }) => match command {
-            Some(DebugCommands::Locator { capstr }) => main_debug_locator(capstr),
-            Some(DebugCommands::Info { capstr, catalog }) => main_debug_info(capstr, catalog),
+            Some(DebugCommands::Locator { readcap }) => main_debug_locator(readcap),
+            Some(DebugCommands::Info {
+                readcap,
+                catalog,
+            }) => main_debug_info(readcap, catalog),
             None => Ok(()),
         },
         Some(Commands::Anthology { command }) => match command {
             Some(AnthologyCommands::Create { directory }) => main_anthology_create(directory),
-            Some(AnthologyCommands::List { capstr }) => main_anthology_list(capstr),
+            Some(AnthologyCommands::List { readcap }) => main_anthology_list(readcap),
             None => Ok(()),
         },
         None => Ok(()),

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -439,17 +439,17 @@ pub fn main_publish(
 }
 
 /// "mcap debug locator"
-pub fn main_debug_locator(capstr: &str) -> Result<(), MagicCapError> {
-    if let Ok::<ImmutableReadCap, _>(cap) = capstr.try_into() {
-        let id: ImmutableIdentifier = cap.into();
-        println!("{id}");
-    }
-    // todo: verify cap?
+pub fn main_debug_locator(readcap: &ImmutableReadCap) -> Result<(), MagicCapError> {
+    let id: ImmutableIdentifier = readcap.into();
+    println!("{id}");
     Ok(())
 }
 
 /// "mcap debug info"
-pub fn main_debug_info(capstr: &str, catalog: &Option<PathBuf>) -> Result<(), MagicCapError> {
+pub fn main_debug_info(
+    readcap: &ImmutableReadCap,
+    catalog: &Option<PathBuf>,
+) -> Result<(), MagicCapError> {
     if !catalog.is_some() {
         return Err(MagicCapError::GenericError(
             "Need a catalog to find readcap metadata".to_string(),
@@ -457,19 +457,17 @@ pub fn main_debug_info(capstr: &str, catalog: &Option<PathBuf>) -> Result<(), Ma
     }
     let catalog = ImmutableDirectoryCatalog::create(catalog.clone().unwrap())?;
 
-    if let Ok::<ImmutableReadCap, _>(cap) = capstr.try_into() {
-        let id: ImmutableIdentifier = (&cap).into();
-        let imm = catalog.load(&id)?;
-        let meta = imm.metadata;
-        println!("location-id: {id}");
-        println!(" block-size: {}", meta.block_size);
-        println!("      bytes: {}", meta.size);
-        println!("     blocks: {}", meta.blocks);
-        println!("encrypted metadata:");
-        let secret_meta = meta.secret_metadata(&cap);
-        for (k, v) in secret_meta.data {
-            println!("  {k:>20}: {v}");
-        }
+    let id: ImmutableIdentifier = (readcap).into();
+    let imm = catalog.load(&id)?;
+    let meta = imm.metadata;
+    println!("location-id: {id}");
+    println!(" block-size: {}", meta.block_size);
+    println!("      bytes: {}", meta.size);
+    println!("     blocks: {}", meta.blocks);
+    println!("encrypted metadata:");
+    let secret_meta = meta.secret_metadata(&readcap);
+    for (k, v) in secret_meta.data {
+        println!("  {k:>20}: {v}");
     }
     Ok(())
 }
@@ -535,14 +533,13 @@ pub fn main_anthology_create(directory: &Path) -> Result<(), MagicCapError> {
     Ok(())
 }
 
-pub fn main_anthology_list(capstr: &str) -> Result<(), MagicCapError> {
+pub fn main_anthology_list(readcap: &ImmutableReadCap) -> Result<(), MagicCapError> {
     // need a catalog -- waiting for shapr's PR to "promote" it to top-level
     let catalog = ImmutableDirectoryCatalog::create(PathBuf::from("data/root"))?;
-    let cap: ImmutableReadCap = capstr.try_into()?;
 
-    let id: ImmutableIdentifier = cap.clone().into();
+    let id: ImmutableIdentifier = readcap.clone().into();
     let mut anthology = catalog.load(&id)?;
-    let plaintext = cap.decrypt(&mut anthology)?;
+    let plaintext = readcap.decrypt(&mut anthology)?;
 
     debug!("{:?}", anthology.metadata);
     for line in plaintext.lines().map_while(Result::ok) {

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -175,8 +175,8 @@ pub fn main_encrypt(
         }
         let (cap, _) = cryptor.done()?;
 
-        let capstr = format!("{}", cap);
-        writeln!(output, "{}", capstr)?;
+        let capstr = format!("{cap}");
+        writeln!(output, "{capstr}")?;
         return Ok(());
     };
 
@@ -190,8 +190,8 @@ pub fn main_encrypt(
     }
     let (cap, _) = cryptor.done()?;
 
-    let capstr = format!("{}", cap);
-    writeln!(output, "{}", capstr)?;
+    let capstr = format!("{cap}");
+    writeln!(output, "{capstr}")?;
     Ok(())
 }
 
@@ -309,7 +309,7 @@ fn cap_match(
         Err(e) => match &e {
             MagicCapError::McapMetadataDiscordant() => Err(e),
             _ => {
-                writeln!(output, "Error decrypting: {}", e)?;
+                writeln!(output, "Error decrypting: {e}")?;
                 Ok(())
             }
         },
@@ -341,9 +341,9 @@ pub fn main_verify(capstr: &str, input_fname: &Path) -> Result<(), MagicCapError
 pub fn main_reduce(output: &mut impl Write, cap: &str) -> Result<(), MagicCapError> {
     if let Ok(readcap) = ImmutableReadCap::try_from(cap) {
         let verifycap = ImmutableVerifyCap::from(readcap);
-        writeln!(output, "{}", verifycap)?;
+        writeln!(output, "{verifycap}")?;
     } else if let Ok(verifycap) = ImmutableVerifyCap::try_from(cap) {
-        writeln!(output, "{}", verifycap)?;
+        writeln!(output, "{verifycap}")?;
     } else {
         writeln!(output, "Unknown kind of cap.")?;
         return Err(MagicCapError::InvalidCap(cap.to_string()));
@@ -357,7 +357,7 @@ pub fn main_publish(
     catalog: &PathBuf,
     output: &PathBuf,
 ) -> Result<(), MagicCapError> {
-    writeln!(stdout, "publish {:?} to {:?}", catalog, output)?;
+    writeln!(stdout, "publish {catalog:?} to {output:?}")?;
     if output.exists() {
         return Err(MagicCapError::GenericError(format!(
             "\"{}\" already exists",
@@ -442,7 +442,7 @@ pub fn main_publish(
 pub fn main_debug_locator(capstr: &str) -> Result<(), MagicCapError> {
     if let Ok::<ImmutableReadCap, _>(cap) = capstr.try_into() {
         let id: ImmutableIdentifier = cap.into();
-        println!("{}", id);
+        println!("{id}");
     }
     // todo: verify cap?
     Ok(())
@@ -461,7 +461,7 @@ pub fn main_debug_info(capstr: &str, catalog: &Option<PathBuf>) -> Result<(), Ma
         let id: ImmutableIdentifier = (&cap).into();
         let imm = catalog.load(&id)?;
         let meta = imm.metadata;
-        println!("location-id: {}", id);
+        println!("location-id: {id}");
         println!(" block-size: {}", meta.block_size);
         println!("      bytes: {}", meta.size);
         println!("     blocks: {}", meta.blocks);
@@ -483,7 +483,7 @@ pub struct AnthologyEntry {
 //pub fn create_anthology(entries: Vec<AnthologyEntry>) -> Result<dyn Read>;
 
 /// "mcap anthology create"
-pub fn main_anthology_create(directory: &PathBuf) -> Result<(), MagicCapError> {
+pub fn main_anthology_create(directory: &Path) -> Result<(), MagicCapError> {
     // need a catalog -- waiting for shapr's PR to "promote" it to top-level
     let mut catalog = ImmutableDirectoryCatalog::create(PathBuf::from("data/root"))?;
 
@@ -496,28 +496,29 @@ pub fn main_anthology_create(directory: &PathBuf) -> Result<(), MagicCapError> {
     // refactor into own function
     let mut anthology: Vec<AnthologyEntry> = vec![];
 
-    for p in directory.read_dir().expect("Cannot list directory") {
-        if let Ok(p) = p {
-            let t = p.file_type().expect("Cannot stat file");
-            if t.is_file() {
-                debug!("Encoding file {:?}", p.file_name());
-                let mut builder = catalog.insert(4096).expect("Creating catalog entry");
-                let mut path: std::path::PathBuf = directory.clone();
-                path.push(p.file_name());
-                let mut plaintext =
-                    std::io::BufReader::new(std::fs::File::open(path.clone()).unwrap());
-                let written = std::io::copy(&mut plaintext, &mut builder).expect("Copy failed");
-                let (cap, _) = builder.done().expect("Failed to finalize Immutable");
-                eprintln!("{}: {} bytes", path.display(), written);
-                anthology.push(AnthologyEntry {
-                    name: format!("{}", p.file_name().display()),
-                    cap,
-                });
-            }
+    for p in directory
+        .read_dir()
+        .expect("Cannot list directory")
+        .flatten()
+    {
+        let t = p.file_type().expect("Cannot stat file");
+        if t.is_file() {
+            debug!("Encoding file {:?}", p.file_name());
+            let mut builder = catalog.insert(4096).expect("Creating catalog entry");
+            let mut path: std::path::PathBuf = directory.to_path_buf();
+            path.push(p.file_name());
+            let mut plaintext = std::io::BufReader::new(std::fs::File::open(path.clone()).unwrap());
+            let written = std::io::copy(&mut plaintext, &mut builder).expect("Copy failed");
+            let (cap, _) = builder.done().expect("Failed to finalize Immutable");
+            eprintln!("{}: {} bytes", path.display(), written);
+            anthology.push(AnthologyEntry {
+                name: format!("{}", p.file_name().display()),
+                cap,
+            });
         }
     }
 
-    if anthology.len() == 0 {
+    if anthology.is_empty() {
         return Err(MagicCapError::GenericError("Empty Anthology".to_string()));
     }
 
@@ -529,7 +530,7 @@ pub fn main_anthology_create(directory: &PathBuf) -> Result<(), MagicCapError> {
         writeln!(builder, "{} {}", entry.cap, entry.name).expect("Writing anthology entry");
     }
     let (cap, _) = builder.done().expect("Failed to finalize Immutable");
-    println!("{}", cap);
+    println!("{cap}");
 
     Ok(())
 }
@@ -544,18 +545,16 @@ pub fn main_anthology_list(capstr: &str) -> Result<(), MagicCapError> {
     let plaintext = cap.decrypt(&mut anthology)?;
 
     debug!("{:?}", anthology.metadata);
-    for line in plaintext.lines() {
-        if let Ok(line) = line {
-            debug!("{:?}", line);
-            let two: Vec<&str> = line.split(" ").collect();
-            if two.len() != 2 {
-                return Err(MagicCapError::GenericError(
-                    "illegal line in Anthology".to_string(),
-                ));
-            }
-            let name = two[1];
-            println!("{}", name);
+    for line in plaintext.lines().map_while(Result::ok) {
+        debug!("{:?}", line);
+        let two: Vec<&str> = line.split(' ').collect();
+        if two.len() != 2 {
+            return Err(MagicCapError::GenericError(
+                "illegal line in Anthology".to_string(),
+            ));
         }
+        let name = two[1];
+        println!("{name}");
     }
 
     Ok(())

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -465,7 +465,7 @@ pub fn main_debug_info(
     println!("      bytes: {}", meta.size);
     println!("     blocks: {}", meta.blocks);
     println!("encrypted metadata:");
-    let secret_meta = meta.secret_metadata(&readcap);
+    let secret_meta = meta.secret_metadata(readcap);
     for (k, v) in secret_meta.data {
         println!("  {k:>20}: {v}");
     }

--- a/mcap/src/tests.rs
+++ b/mcap/src/tests.rs
@@ -35,7 +35,7 @@ pub mod test {
             println!("creating plain file at {:?}",plain);
             {
                 let mut tmp = File::create(&plain)?;
-                tmp.write(s.as_bytes())?;
+                let _written_amount = tmp.write(s.as_bytes())?;
             }  // close tmp
             println!("finished writing to tmp");
             let cipher = outd.path().join("cipher");


### PR DESCRIPTION
This commit converts the parsed `Url` into a string, appends the `/` character, and re-parses the resulting string into a `Url`

This fixes #27 in the least attractive way.