### PR TITLE
use Url::path_segments_mut()

### DIFF
--- a/magic_cap/src/catalog.rs
+++ b/magic_cap/src/catalog.rs
@@ -130,8 +130,10 @@ impl ImmutableWebCatalog {
     pub fn create(root: Url) -> Result<ImmutableWebCatalog, MagicCapError> {
         debug!("start of ImmutableWebCatalog create");
         // figure out of this looks like a Magic Cap Catalog version 0 REST API
-        let url = root.clone();
-        let url = url.join("magic-cap-catalog").unwrap();
+        let mut url = root.clone();
+        url.path_segments_mut()
+            .expect("Valid base URL")
+            .push("magic-cap-catalog");
         debug!("url is {}", url);
         let result = reqwest::blocking::Client::new().get(url).send()?;
         debug!("before js result.text");
@@ -148,10 +150,12 @@ impl ImmutableWebCatalog {
         &self,
         location: &ImmutableIdentifier,
     ) -> Result<ImmutableMetadata, MagicCapError> {
-        let url = self.root.clone();
+        let mut url = self.root.clone();
         let id_str: String = location.into();
-        let url = url.join((id_str + "/").as_str()).unwrap();
-        let url = url.join("metadata").unwrap();
+        url.path_segments_mut()
+            .expect("Valid base URL")
+            .push((id_str + "/").as_str())
+            .push("metadata");
         debug!("URL {:?}", url);
         let result = reqwest::blocking::Client::new()
             .get(url)
@@ -168,10 +172,12 @@ impl ImmutableWebCatalog {
         location: &ImmutableIdentifier,
         dest: &mut dyn Write,
     ) -> Result<(), MagicCapError> {
-        let url = self.root.clone();
+        let mut url = self.root.clone();
         let id_str: String = location.into();
-        let url = url.join((id_str + "/").as_str()).unwrap();
-        let url = url.join("ciphertext").unwrap();
+        url.path_segments_mut()
+            .expect("Valid base URL")
+            .push((id_str + "/").as_str())
+            .push("ciphertext");
         debug!("URL {:?}", url);
         let mut result = reqwest::blocking::Client::new().get(url).send()?;
         result.copy_to(dest)?;

--- a/magic_cap/src/lib.rs
+++ b/magic_cap/src/lib.rs
@@ -5,7 +5,11 @@
 //! the corresponding plaintext when presented alongside the correct
 //! ciphertext.
 //!
-//! The repository README has diagrams <https://github.com/magic-cap/magic-cap>
+//! - Crate: <https://docs.rs/magic_cap/latest/magic_cap/>
+//! - CLI: <https://docs.rs/magic_cap_cli/latest/magic_cap_cli/>
+//! - Code: <https://github.com/magic-cap/magic-cap>
+//! - User Documentation: <https://magic-cap.readthedocs.io/en/latest/>
+//! - API Documentation: <https://docs.rs/magic_cap/latest/magic_cap/>
 //!
 //! <div class="warning">
 //! This is a release-early library that has <b>not yet received cryptographic (or other) audits</b>.

--- a/mcap/src/lib.rs
+++ b/mcap/src/lib.rs
@@ -646,7 +646,7 @@ impl Locator for CatalogUrl {
         readcap: &ImmutableReadCap,
         output: &mut impl Write,
     ) -> Result<(), MagicCapError> {
-        debug!("before catalog create");
+        debug!("before catalog create {}", self.catalog_url);
         let collect = ImmutableWebCatalog::create(self.catalog_url.clone())?;
         let tahoe_cap = readcap.clone();
         debug!("before readcap.into");


### PR DESCRIPTION
 ...instead of Url::join for consistent trailing-slash behavior.

Alternative fix for https://github.com/magic-cap/magic-cap/issues/27